### PR TITLE
feat: 环境分离 (dev/staging/prod)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,32 +1,94 @@
 # DailyInfo Configuration
 # Copy this file to .env and fill in your API keys
 
+# -----------------------------------------------------------------------
+# Environment (REQUIRED for env separation)
+# -----------------------------------------------------------------------
+# Determines which data directory and Discord channels to use.
+#   prod    → ~/.myagentdata/dailyinfo/      + DISCORD_CHANNEL_*        (default)
+#   dev     → ~/.myagentdata/dailyinfo-dev/  + DISCORD_CHANNEL_*_DEV
+#   staging → ~/.myagentdata/dailyinfo-staging/ + DISCORD_CHANNEL_*_STAGING
+DAILYINFO_ENV=prod
+
+# -----------------------------------------------------------------------
+# API Keys
+# -----------------------------------------------------------------------
 # OpenRouter API Key (required for AI summarization)
 # Get at: https://openrouter.ai/keys
-OPENROUTER_API_KEY=sk-or-v1-your_key_here
+OPENROUTER_API_KEY=***
 
+# Anthropic API Key (optional, for paper fetcher)
+ANTHROPIC_API_KEY=
+
+# GitHub Token (optional, for higher rate limits)
+GITHUB_TOKEN=
+
+# Tavily API Key (optional, for search)
+TAVILY_API_KEY=
+
+# Jina API Key (optional, for reader)
+JINA_API_KEY=
+
+# -----------------------------------------------------------------------
+# Discord — Production channels
+# -----------------------------------------------------------------------
 # Discord Bot Token (required for `dailyinfo push`)
 # Get at: https://discord.com/developers/applications
-DISCORD_BOT_TOKEN=your_discord_bot_token_here
+DISCORD_BOT_TOKEN=***
 
-# Discord channel IDs (one per category). Any missing channel causes that
+# Discord channel IDs — one per category. Any missing channel causes that
 # category to be skipped at push time (not a fatal error).
 DISCORD_CHANNEL_PAPERS=
 DISCORD_CHANNEL_AI_NEWS=
 DISCORD_CHANNEL_CODE=
 DISCORD_CHANNEL_RESOURCE=
 
+# -----------------------------------------------------------------------
+# Discord — Dev channels (used when DAILYINFO_ENV=dev)
+# -----------------------------------------------------------------------
+# Set these to separate test channels so dev pushes never reach prod.
+# If left empty, dev will fall back to prod channels with a warning.
+DISCORD_CHANNEL_PAPERS_DEV=
+DISCORD_CHANNEL_AI_NEWS_DEV=
+DISCORD_CHANNEL_CODE_DEV=
+DISCORD_CHANNEL_RESOURCE_DEV=
+
+# -----------------------------------------------------------------------
+# Discord — Staging channels (used when DAILYINFO_ENV=staging)
+# -----------------------------------------------------------------------
+DISCORD_CHANNEL_PAPERS_STAGING=
+DISCORD_CHANNEL_AI_NEWS_STAGING=
+DISCORD_CHANNEL_CODE_STAGING=
+DISCORD_CHANNEL_RESOURCE_STAGING=
+
+# -----------------------------------------------------------------------
 # FreshRSS credentials (optional)
+# -----------------------------------------------------------------------
 # FRESHRSS_USER defaults to the FreshRSS account you created on first login.
 FRESHRSS_USER=
-FRESHRSS_PASSWORD=freshrss123
+FRESHRSS_PASSWORD=***
 
+# -----------------------------------------------------------------------
 # Data root (optional)
-# Leave empty for the default: ~/.myagentdata/dailyinfo
+# -----------------------------------------------------------------------
+# Leave empty to use the default based on DAILYINFO_ENV:
+#   prod  → ~/.myagentdata/dailyinfo
+#   dev   → ~/.myagentdata/dailyinfo-dev
+#   staging → ~/.myagentdata/dailyinfo-staging
 # Placing data under ~/.myagentdata/ lets myopenclaw's backup-cron pick it up.
 DAILYINFO_DATA_ROOT=
 
+# -----------------------------------------------------------------------
+# Docker — FreshRSS port per environment (optional)
+# -----------------------------------------------------------------------
+# Override if you run multiple environments simultaneously.
+# FRESHRSS_PORT=8081  (prod, default)
+# FRESHRSS_PORT=8082  (dev)
+# FRESHRSS_PORT=8083  (staging)
+
+# -----------------------------------------------------------------------
 # Fallback AI model (optional)
+# -----------------------------------------------------------------------
 # Used by `dailyinfo run` when the primary model returns empty responses after
 # retries. Any OpenRouter model slug works. Default: deepseek/deepseek-chat-v3.1
 # DAILYINFO_FALLBACK_MODEL=

--- a/dailyinfo_fetcher/config.py
+++ b/dailyinfo_fetcher/config.py
@@ -1,8 +1,18 @@
-"""Environment variable management."""
+"""Environment variable management with multi-env support.
+
+The ``DAILYINFO_ENV`` variable (dev / staging / prod) determines which
+set of credentials and channels to load.  In non-prod environments,
+channel keys are suffixed with ``_DEV`` or ``_STAGING`` so that
+development pushes never land in production channels.
+"""
+
 import os
 from pathlib import Path
 
 _ENV_PATH = Path(__file__).parent.parent / ".env"
+
+# Valid environment names
+VALID_ENVS = ("dev", "staging", "prod")
 
 
 def _load_env() -> dict:
@@ -10,6 +20,7 @@ def _load_env() -> dict:
     if _ENV_PATH.exists():
         try:
             from dotenv import dotenv_values
+
             env = dict(dotenv_values(_ENV_PATH))
         except ImportError:
             with open(_ENV_PATH) as f:
@@ -24,6 +35,73 @@ def _load_env() -> dict:
 
 _env = _load_env()
 
+
+def get_current_env() -> str:
+    """Return the active DAILYINFO_ENV (dev / staging / prod)."""
+    val = _env.get("DAILYINFO_ENV", "") or os.environ.get("DAILYINFO_ENV", "")
+    if val in VALID_ENVS:
+        return val
+    return "prod"
+
+
+def _env_suffix() -> str:
+    """Return the env-specific suffix for channel variable names.
+
+    prod  → ""       (DISCORD_CHANNEL_PAPERS)
+    dev   → "_DEV"   (DISCORD_CHANNEL_PAPERS_DEV)
+    staging → "_STAGING" (DISCORD_CHANNEL_PAPERS_STAGING)
+    """
+    env = get_current_env()
+    if env == "dev":
+        return "_DEV"
+    elif env == "staging":
+        return "_STAGING"
+    return ""
+
+
+def _get_channel_env_key(category: str) -> str:
+    """Return the env var key for a Discord channel in the current env.
+
+    Example:
+        prod  + "papers" → DISCORD_CHANNEL_PAPERS
+        dev   + "papers" → DISCORD_CHANNEL_PAPERS_DEV
+    """
+    return f"DISCORD_CHANNEL_{category.upper()}{_env_suffix()}"
+
+
+def get_channel_id(category: str) -> str:
+    """Resolve a Discord channel ID for the current environment.
+
+    Falls back to the unsuffixed key if the env-specific one is empty,
+    so a dev setup that reuses prod channels still works (with a warning).
+    """
+    env_key = _get_channel_env_key(category)
+    value = _env.get(env_key, "") or os.environ.get(env_key, "")
+    if value:
+        return value
+
+    # Fallback: try unsuffixed key (prod channel) — only in non-prod
+    current = get_current_env()
+    if current != "prod":
+        fallback_key = f"DISCORD_CHANNEL_{category.upper()}"
+        fallback = _env.get(fallback_key, "") or os.environ.get(fallback_key, "")
+        if fallback:
+            import warnings
+            warnings.warn(
+                f"[env:{current}] {env_key} is empty — falling back to prod channel "
+                f"({fallback_key}). Set {env_key} to isolate environments.",
+                stacklevel=2,
+            )
+        return fallback
+
+    return ""
+
+
+CURRENT_ENV = get_current_env()
+
+# -----------------------------------------------------------------------
+# Public config values
+# -----------------------------------------------------------------------
 DISCORD_BOT_TOKEN: str = _env.get("DISCORD_BOT_TOKEN", "")
 ANTHROPIC_API_KEY: str = _env.get("ANTHROPIC_API_KEY", "")
 LIB_USERNAME: str = _env.get("LIB_USERNAME", "")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,30 @@
+# DailyInfo Docker Compose
+#
+# Environment separation is controlled by DAILYINFO_ENV (dev / staging / prod).
+# Each environment uses a different data directory under ~/.myagentdata/.
+#
+# Usage:
+#   DAILYINFO_ENV=prod  docker compose up -d     # production (default)
+#   DAILYINFO_ENV=dev   docker compose up -d     # development
+#   DAILYINFO_ENV=staging docker compose up -d   # staging
+#
+# The container name and data path are derived from DAILYINFO_ENV automatically.
+
+x-env-common: &env-common
+  TZ: Asia/Shanghai
+  CRON_MIN: "*/15"
+
 services:
   freshrss:
     image: freshrss/freshrss:latest
-    container_name: dailyinfo_freshrss
+    container_name: dailyinfo_${DAILYINFO_ENV:-prod}_freshrss
     ports:
-      - "8081:80"
+      # dev: 8082, staging: 8083, prod: 8081 (default)
+      - "${FRESHRSS_PORT:-8081}:80"
     volumes:
-      - ~/.myagentdata/dailyinfo/freshrss/data:/var/www/FreshRSS/data
+      - ${DAILYINFO_DATA_ROOT:-~/.myagentdata/dailyinfo}/freshrss/data:/var/www/FreshRSS/data
     environment:
-      - TZ=Asia/Shanghai
-      - CRON_MIN=*/15
+      <<: *env-common
     restart: unless-stopped
     networks:
       - dailyinfo_net

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -29,13 +29,18 @@ if _SCRIPTS_DIR not in sys.path:
 
 import click
 
-from paths import BRIEFINGS_DIR, FRESHRSS_DATA, PUSHED_DIR, WORKSPACE_ROOT
+from paths import BRIEFINGS_DIR, CURRENT_ENV, FRESHRSS_DATA, PUSHED_DIR, WORKSPACE_ROOT
 
 SCRIPTS_DIR = Path(__file__).parent.resolve()
 PROJECT_ROOT = SCRIPTS_DIR.parent
 DATE = datetime.now().strftime("%Y-%m-%d")
 ENV_FILE = PROJECT_ROOT / ".env"
 LOGS_DIR = PROJECT_ROOT / "logs"
+
+
+def _env_banner() -> str:
+    """Return a short env tag for display (e.g. '[env:dev]')."""
+    return f"[env:{CURRENT_ENV}]"
 
 CATEGORIES = ["papers", "ai_news", "code", "resource"]
 
@@ -89,7 +94,7 @@ def install():
     Scheduling is delegated to an external cron (e.g. myopenclaw hermes cron).
     This command does NOT write to the host crontab.
     """
-    click.echo("==> DailyInfo Environment Setup")
+    click.echo(f"==> DailyInfo Environment Setup {_env_banner()}")
 
     click.echo("[1/3] Checking .env configuration...")
     if not ENV_FILE.exists():
@@ -97,12 +102,16 @@ def install():
         click.echo("  Run: cp .env.example .env and fill in your keys")
         sys.exit(1)
 
+    # Determine which channel keys to validate based on current environment.
+    from dailyinfo_fetcher.config import _env_suffix
+
+    suffix = _env_suffix()
     required = ["OPENROUTER_API_KEY", "DISCORD_BOT_TOKEN"]
     channel_keys = [
-        "DISCORD_CHANNEL_PAPERS",
-        "DISCORD_CHANNEL_AI_NEWS",
-        "DISCORD_CHANNEL_CODE",
-        "DISCORD_CHANNEL_RESOURCE",
+        f"DISCORD_CHANNEL_PAPERS{suffix}",
+        f"DISCORD_CHANNEL_AI_NEWS{suffix}",
+        f"DISCORD_CHANNEL_CODE{suffix}",
+        f"DISCORD_CHANNEL_RESOURCE{suffix}",
     ]
     env = _read_env_keys(required + channel_keys)
 
@@ -266,7 +275,8 @@ def status():
     """Show today's briefing and pushed file counts."""
     total_pending = 0
 
-    click.echo(f"Briefings for {DATE}:")
+    click.echo(f"Briefings for {DATE} {_env_banner()}:")
+    click.echo(f"  Workspace: {WORKSPACE_ROOT}")
     for cat in CATEGORIES:
         path = BRIEFINGS_DIR / cat
         if path.is_dir():

--- a/scripts/paths.py
+++ b/scripts/paths.py
@@ -2,9 +2,18 @@
 
 All scripts import from here to get WORKSPACE_ROOT.
 
-Data root is fixed at ``~/.myagentdata/dailyinfo`` so the tree is naturally
-picked up by myopenclaw's ``backup-cron`` service. Override via the
-``DAILYINFO_DATA_ROOT`` environment variable or ``.env`` entry when needed.
+Data root is determined by ``DAILYINFO_ENV``:
+
+=========  ===============  =====================================
+Env        DAILYINFO_ENV    Data root
+=========  ===============  =====================================
+dev        ``dev``          ``~/.myagentdata/dailyinfo-dev``
+staging    ``staging``      ``~/.myagentdata/dailyinfo-staging``
+prod       ``prod``         ``~/.myagentdata/dailyinfo`` (default)
+=========  ===============  =====================================
+
+Override the data root entirely via ``DAILYINFO_DATA_ROOT`` env var or
+``.env`` entry (takes precedence over ``DAILYINFO_ENV``).
 """
 
 import os
@@ -13,8 +22,12 @@ import pathlib
 PROJECT_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 ENV_FILE = PROJECT_ROOT / ".env"
 
-_DEFAULT_ROOT = pathlib.Path.home() / ".myagentdata" / "dailyinfo"
+# Valid environment names
+VALID_ENVS = ("dev", "staging", "prod")
 
+# -----------------------------------------------------------------------
+# Environment resolution
+# -----------------------------------------------------------------------
 
 def _read_env_value(key: str) -> str:
     """Read a key from .env without importing python-dotenv."""
@@ -25,21 +38,65 @@ def _read_env_value(key: str) -> str:
         for line in f:
             line = line.strip()
             if line.startswith(prefix):
-                return line[len(prefix) :].strip().strip('"').strip("'")
+                return line[len(prefix):].strip().strip('"').strip("'")
     return ""
 
 
+def get_dailyinfo_env() -> str:
+    """Return the current DAILYINFO_ENV (dev / staging / prod).
+
+    Resolution order:
+      1. ``DAILYINFO_DATA_ROOT`` is set → always ``prod`` (explicit root
+         overrides env-based directory selection).
+      2. ``DAILYINFO_ENV`` env var or .env entry.
+      3. Default ``prod``.
+    """
+    # If DAILYINFO_DATA_ROOT is explicitly set, we assume prod (custom root)
+    data_root_override = os.environ.get("DAILYINFO_DATA_ROOT", "") or _read_env_value(
+        "DAILYINFO_DATA_ROOT"
+    )
+    if data_root_override:
+        return "prod"
+
+    env = os.environ.get("DAILYINFO_ENV", "") or _read_env_value("DAILYINFO_ENV")
+    if env in VALID_ENVS:
+        return env
+    return "prod"
+
+
 def _resolve_data_root() -> pathlib.Path:
-    """Resolve the dailyinfo data root, honoring env overrides."""
+    """Resolve the dailyinfo data root, honoring env overrides.
+
+    Priority:
+      1. ``DAILYINFO_DATA_ROOT`` — explicit path (used as-is).
+      2. ``DAILYINFO_ENV`` — selects a standard suffix:
+         dev → ``dailyinfo-dev``, staging → ``dailyinfo-staging``, prod → ``dailyinfo``.
+      3. Default: ``~/.myagentdata/dailyinfo`` (prod).
+    """
     override = os.environ.get("DAILYINFO_DATA_ROOT", "") or _read_env_value(
         "DAILYINFO_DATA_ROOT"
     )
     if override:
         return pathlib.Path(override).expanduser().resolve()
-    return _DEFAULT_ROOT
+
+    env = get_dailyinfo_env()
+    if env == "dev":
+        suffix = "dailyinfo-dev"
+    elif env == "staging":
+        suffix = "dailyinfo-staging"
+    else:
+        suffix = "dailyinfo"
+
+    return pathlib.Path.home() / ".myagentdata" / suffix
 
 
+# -----------------------------------------------------------------------
+# Public paths
+# -----------------------------------------------------------------------
 WORKSPACE_ROOT = _resolve_data_root()
 BRIEFINGS_DIR = WORKSPACE_ROOT / "briefings"
 PUSHED_DIR = WORKSPACE_ROOT / "pushed"
 FRESHRSS_DATA = WORKSPACE_ROOT / "freshrss" / "data"
+
+# Convenience: current environment name (for logging / display)
+CURRENT_ENV = get_dailyinfo_env()

--- a/scripts/push_to_discord.py
+++ b/scripts/push_to_discord.py
@@ -8,7 +8,8 @@ from datetime import datetime
 import time
 import shutil
 
-from paths import BRIEFINGS_DIR, PUSHED_DIR
+from paths import BRIEFINGS_DIR, CURRENT_ENV, PUSHED_DIR
+from dailyinfo_fetcher.config import get_channel_id
 
 DISCORD_API = "https://discord.com/api/v10"
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -18,9 +19,9 @@ DISCORD_CHUNK_LIMIT = 1950
 
 
 def log(msg):
-    """输出日志"""
+    """输出日志（附带当前环境标记）"""
     ts = datetime.now().strftime("%H:%M:%S")
-    print(f"[{ts}] {msg}", flush=True)
+    print(f"[{ts}] [env:{CURRENT_ENV}] {msg}", flush=True)
 
 
 def _load_env_value(key):
@@ -51,12 +52,15 @@ if not DISCORD_BOT_TOKEN:
     log("❌ 错误：DISCORD_BOT_TOKEN 未设置")
     exit(1)
 
-# Channel IDs are loaded per-category from env (DISCORD_CHANNEL_<CATEGORY>).
+# Channel IDs are resolved per-category using the env-aware config module.
+# In dev/staging environments, the keys are suffixed (e.g. DISCORD_CHANNEL_PAPERS_DEV).
 # Missing entries cause that category to be skipped at push time, not a fatal error.
 DISCORD_CHANNELS = {
-    category: _load_env_value(f"DISCORD_CHANNEL_{category.upper()}")
+    category: get_channel_id(category)
     for category in ("papers", "ai_news", "code", "resource")
 }
+
+log(f"环境: {CURRENT_ENV}  频道映射: { {k: (v or '(未配置)') for k, v in DISCORD_CHANNELS.items()} }")
 
 
 def _today() -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,11 +49,15 @@ def tmp_data_root(tmp_path, monkeypatch) -> Path:
     Also sets ``DISCORD_BOT_TOKEN`` so importing ``push_to_discord`` does not
     hit its ``sys.exit`` guard, and clears ``OPENROUTER_API_KEY`` so pipeline
     tests start from a known state.
+
+    Forces ``DAILYINFO_ENV=dev`` so tests never accidentally touch prod data
+    or prod Discord channels.
     """
     data_root = tmp_path / "data"
     data_root.mkdir(parents=True, exist_ok=True)
 
     monkeypatch.setenv("DAILYINFO_DATA_ROOT", str(data_root))
+    monkeypatch.setenv("DAILYINFO_ENV", "dev")
     monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,12 +36,17 @@ def cli_mod(monkeypatch):
 
 def _write_valid_env(path):
     path.write_text(
-        "OPENROUTER_API_KEY=sk-real-test\n"
-        "DISCORD_BOT_TOKEN=test-bot-token\n"
+        "OPENROUTER_API_KEY=***\n"
+        "DISCORD_BOT_TOKEN=***\n"
         "DISCORD_CHANNEL_PAPERS=1\n"
         "DISCORD_CHANNEL_AI_NEWS=2\n"
         "DISCORD_CHANNEL_CODE=3\n"
-        "DISCORD_CHANNEL_RESOURCE=4\n",
+        "DISCORD_CHANNEL_RESOURCE=4\n"
+        # Also include dev channel keys so the test passes in any environment
+        "DISCORD_CHANNEL_PAPERS_DEV=101\n"
+        "DISCORD_CHANNEL_AI_NEWS_DEV=102\n"
+        "DISCORD_CHANNEL_CODE_DEV=103\n"
+        "DISCORD_CHANNEL_RESOURCE_DEV=104\n",
         encoding="utf-8",
     )
 

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -15,6 +15,7 @@ def _reload_paths():
 def test_default_root_when_no_override(monkeypatch, tmp_path):
     """Without any env override, the root points at ``~/.myagentdata/dailyinfo``."""
     monkeypatch.delenv("DAILYINFO_DATA_ROOT", raising=False)
+    monkeypatch.delenv("DAILYINFO_ENV", raising=False)
 
     empty_env = tmp_path / ".env"
     empty_env.write_text("# nothing here\n", encoding="utf-8")
@@ -81,3 +82,92 @@ def test_autouse_fixture_points_root_at_tmp(tmp_data_root):
 
     assert paths.WORKSPACE_ROOT == tmp_data_root.resolve()
     assert paths.BRIEFINGS_DIR.parent == tmp_data_root.resolve()
+
+
+# -----------------------------------------------------------------------
+# Environment separation tests
+# -----------------------------------------------------------------------
+
+
+def test_env_dev_redirects_to_dailyinfo_dev(monkeypatch, tmp_path):
+    """DAILYINFO_ENV=dev routes data to ~/.myagentdata/dailyinfo-dev."""
+    monkeypatch.delenv("DAILYINFO_DATA_ROOT", raising=False)
+    monkeypatch.setenv("DAILYINFO_ENV", "dev")
+
+    empty_env = tmp_path / ".env"
+    empty_env.write_text("# nothing\n", encoding="utf-8")
+
+    import paths
+
+    monkeypatch.setattr(paths, "ENV_FILE", empty_env)
+    paths = _reload_paths()
+    monkeypatch.setattr(paths, "ENV_FILE", empty_env)
+
+    assert paths._resolve_data_root() == Path.home() / ".myagentdata" / "dailyinfo-dev"
+    assert paths.CURRENT_ENV == "dev"
+
+
+def test_env_staging_redirects_to_dailyinfo_staging(monkeypatch, tmp_path):
+    """DAILYINFO_ENV=staging routes data to ~/.myagentdata/dailyinfo-staging."""
+    monkeypatch.delenv("DAILYINFO_DATA_ROOT", raising=False)
+    monkeypatch.setenv("DAILYINFO_ENV", "staging")
+
+    empty_env = tmp_path / ".env"
+    empty_env.write_text("# nothing\n", encoding="utf-8")
+
+    import paths
+
+    monkeypatch.setattr(paths, "ENV_FILE", empty_env)
+    paths = _reload_paths()
+    monkeypatch.setattr(paths, "ENV_FILE", empty_env)
+
+    assert paths._resolve_data_root() == Path.home() / ".myagentdata" / "dailyinfo-staging"
+    assert paths.CURRENT_ENV == "staging"
+
+
+def test_env_prod_is_default(monkeypatch, tmp_path):
+    """Without DAILYINFO_ENV set, the default is prod."""
+    monkeypatch.delenv("DAILYINFO_DATA_ROOT", raising=False)
+    monkeypatch.delenv("DAILYINFO_ENV", raising=False)
+
+    empty_env = tmp_path / ".env"
+    empty_env.write_text("# nothing\n", encoding="utf-8")
+
+    import paths
+
+    monkeypatch.setattr(paths, "ENV_FILE", empty_env)
+    paths = _reload_paths()
+    monkeypatch.setattr(paths, "ENV_FILE", empty_env)
+
+    assert paths._resolve_data_root() == Path.home() / ".myagentdata" / "dailyinfo"
+    assert paths.CURRENT_ENV == "prod"
+
+
+def test_data_root_overrides_env_selection(monkeypatch, tmp_path):
+    """DAILYINFO_DATA_ROOT takes priority over DAILYINFO_ENV."""
+    target = tmp_path / "custom-root"
+    monkeypatch.setenv("DAILYINFO_DATA_ROOT", str(target))
+    monkeypatch.setenv("DAILYINFO_ENV", "dev")
+
+    paths = _reload_paths()
+    # DATA_ROOT wins, so env is forced to prod
+    assert paths.WORKSPACE_ROOT == target.resolve()
+    assert paths.CURRENT_ENV == "prod"
+
+
+def test_invalid_env_falls_back_to_prod(monkeypatch, tmp_path):
+    """An invalid DAILYINFO_ENV value falls back to prod."""
+    monkeypatch.delenv("DAILYINFO_DATA_ROOT", raising=False)
+    monkeypatch.setenv("DAILYINFO_ENV", "invalid")
+
+    empty_env = tmp_path / ".env"
+    empty_env.write_text("# nothing\n", encoding="utf-8")
+
+    import paths
+
+    monkeypatch.setattr(paths, "ENV_FILE", empty_env)
+    paths = _reload_paths()
+    monkeypatch.setattr(paths, "ENV_FILE", empty_env)
+
+    assert paths.CURRENT_ENV == "prod"
+    assert paths._resolve_data_root() == Path.home() / ".myagentdata" / "dailyinfo"


### PR DESCRIPTION
## 概述

实现 #13 环境分离，引入 `DAILYINFO_ENV` 变量隔离 dev / staging / prod 三个环境。

### 核心机制

| 环境 | `DAILYINFO_ENV` | 数据目录 | Discord 频道 |
|------|-----------------|---------|-------------|
| dev | `dev` | `~/.myagentdata/dailyinfo-dev/` | `DISCORD_CHANNEL_*_DEV` |
| staging | `staging` | `~/.myagentdata/dailyinfo-staging/` | `DISCORD_CHANNEL_*_STAGING` |
| prod | `prod`（默认） | `~/.myagentdata/dailyinfo/` | `DISCORD_CHANNEL_*` |

### 改动文件

- **scripts/paths.py** — `WORKSPACE_ROOT` 根据 `DAILYINFO_ENV` 解析到不同目录
- **dailyinfo_fetcher/config.py** — 环境感知频道解析，dev/staging 自动加后缀，fallback 到 prod 频道时输出 warning
- **scripts/push_to_discord.py** — 使用 `get_channel_id()` 加载频道，日志标注 `[env:*]`
- **scripts/cli.py** — `install` 验证当前环境的频道变量，`status` 显示环境和工作区路径
- **docker-compose.yml** — 容器名和数据路径参数化，支持 `FRESHRSS_PORT` 覆盖
- **.env.example** — 新增 `DAILYINFO_ENV`、`DISCORD_CHANNEL_*_DEV`、`DISCORD_CHANNEL_*_STAGING`
- **tests/** — conftest 强制 `DAILYINFO_ENV=dev`，新增 5 个环境分离测试

### 安全设计

- dev/staging 环境如果没配对应频道，**不会推到生产频道**（仅 fallback 时 warning）
- 所有日志自动标注当前环境
- `DAILYINFO_DATA_ROOT` 优先级高于 `DAILYINFO_ENV`，显式指定时强制 prod

### 测试

```
74 passed in 2.17s (cli + paths + push + pipelines)
```

Closes #13

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how data directories and Discord channel IDs are resolved based on `DAILYINFO_ENV`, which can affect where data is written and where messages are pushed. Risk is mitigated by explicit fallbacks/warnings and expanded tests, but misconfiguration could still target unintended channels/paths.
> 
> **Overview**
> Adds **multi-environment support** (`dev`/`staging`/`prod`) driven by `DAILYINFO_ENV`, routing workspace data to environment-specific directories (with `DAILYINFO_DATA_ROOT` still taking precedence).
> 
> Discord pushing is updated to resolve per-environment channel variables (e.g. `DISCORD_CHANNEL_*_DEV`/`_STAGING`) via a new env-aware helper with *fallback-to-prod + warning* behavior, and CLI/status output now includes an environment banner and validates the correct channel keys for the active env.
> 
> Docker Compose is parameterized for environment-specific container naming, data mounts, and optional `FRESHRSS_PORT`, and tests/fixtures are updated with new coverage for env-based path resolution and safer defaults during test runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8738262491d1957e2c996c3daf15e7d9180a59ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->