### PR TITLE
feat: split push schedule by category with independent arxiv category

### DIFF
--- a/config/sources.json
+++ b/config/sources.json
@@ -325,7 +325,7 @@
     {
       "name": "arxiv_cs_ai",
       "display_name": "arXiv CS.AI",
-      "category": "ai_news",
+      "category": "arxiv",
       "enabled": true,
       "max_articles_per_batch": 10,
       "max_batches": 50,

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -37,7 +37,7 @@ DATE = datetime.now().strftime("%Y-%m-%d")
 ENV_FILE = PROJECT_ROOT / ".env"
 LOGS_DIR = PROJECT_ROOT / "logs"
 
-CATEGORIES = ["papers", "ai_news", "code", "resource"]
+CATEGORIES = ["papers", "ai_news", "code", "resource", "arxiv"]
 
 
 def _python() -> str:
@@ -103,6 +103,7 @@ def install():
         "DISCORD_CHANNEL_AI_NEWS",
         "DISCORD_CHANNEL_CODE",
         "DISCORD_CHANNEL_RESOURCE",
+        "DISCORD_CHANNEL_ARXIV",
     ]
     env = _read_env_keys(required + channel_keys)
 

--- a/scripts/push_to_discord.py
+++ b/scripts/push_to_discord.py
@@ -55,8 +55,11 @@ if not DISCORD_BOT_TOKEN:
 # Missing entries cause that category to be skipped at push time, not a fatal error.
 DISCORD_CHANNELS = {
     category: _load_env_value(f"DISCORD_CHANNEL_{category.upper()}")
-    for category in ("papers", "ai_news", "code", "resource", "weekly")
+    for category in ("papers", "ai_news", "code", "resource", "arxiv", "weekly")
 }
+# arxiv shares the ai_news Discord channel
+if not DISCORD_CHANNELS.get("arxiv"):
+    DISCORD_CHANNELS["arxiv"] = DISCORD_CHANNELS.get("ai_news")
 
 
 def _today() -> str:
@@ -244,7 +247,7 @@ def build_push_summary(
         and name not in pending_set
     ]
 
-    title = "📊 论文频道推送总结" if category == "papers" else f"📊 {category} 推送总结"
+    title = "📊 论文频道推送总结" if category in ("papers", "arxiv") else f"📊 {category} 推送总结"
     lines = [
         f"{title} ({date})",
         "",
@@ -350,7 +353,7 @@ def push_category(category, channel_id, date=None):
         )
         summary = (
             build_push_summary(category, date, [], placeholder_names)
-            if category == "papers"
+            if category in ("papers", "arxiv")
             else ""
         )
         if summary and send_to_discord(channel_id, summary):
@@ -384,7 +387,7 @@ def push_category(category, channel_id, date=None):
         except Exception as e:
             log(f"  ❌ 处理 {filename} 出错: {e}")
 
-    if category == "papers":
+    if category in ("papers", "arxiv"):
         summary = build_push_summary(
             category, date, pushed_names, placeholder_names, pending_names
         )
@@ -406,8 +409,8 @@ def _parse_date(value):
         ) from exc
 
 
-ALL_CATEGORIES = ["papers", "ai_news", "code", "resource", "weekly"]
-DAILY_CATEGORIES = ["papers", "ai_news", "code", "resource"]
+ALL_CATEGORIES = ["papers", "ai_news", "code", "resource", "arxiv", "weekly"]
+DAILY_CATEGORIES = ["papers", "ai_news", "code", "resource", "arxiv"]
 
 
 def main(date=None, categories=None):
@@ -420,7 +423,7 @@ def main(date=None, categories=None):
 
     total_pushed = 0
 
-    PUSH_ORDER = ["papers", "code", "resource", "ai_news", "weekly"]
+    PUSH_ORDER = ["papers", "code", "resource", "ai_news", "arxiv", "weekly"]
     for category in PUSH_ORDER:
         if category not in active:
             continue

--- a/scripts/run_pipelines.py
+++ b/scripts/run_pipelines.py
@@ -478,7 +478,7 @@ def run_pipeline_1() -> int:
     for source_cfg in cfg["sources"]:
         if source_cfg.get("type") == "rss" or not source_cfg.get("enabled", True):
             continue
-        if source_cfg.get("category") not in ("papers", "ai_news"):
+        if source_cfg.get("category") not in ("papers", "ai_news", "arxiv"):
             continue
 
         ds = DataSource.create(source_cfg, defaults)
@@ -835,7 +835,7 @@ def main() -> int:
             traceback.print_exc()
 
     log("=== Summary ===")
-    for d in ["papers", "ai_news", "code", "resource"]:
+    for d in ["papers", "ai_news", "code", "resource", "arxiv"]:
         path = BRIEFINGS_DIR / d
         if path.exists():
             files = [f.name for f in sorted(path.iterdir()) if DATE in f.name]

--- a/scripts/weekly_summary.py
+++ b/scripts/weekly_summary.py
@@ -145,8 +145,9 @@ def run_weekly_summary(days: int = 7, force: bool = False) -> int:
         log(f"  weekly recap already exists for {DATE}, skip (use --force to overwrite)")
         return 0
 
-    log(f"  collecting last {days} days of ai_news briefings...")
+    log(f"  collecting last {days} days of ai_news + arxiv briefings...")
     briefings = collect_week_briefings("ai_news", days)
+    briefings += collect_week_briefings("arxiv", days)
     if not briefings:
         log("  no briefings found in the past week, abort")
         return 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,7 +41,8 @@ def _write_valid_env(path):
         "DISCORD_CHANNEL_PAPERS=1\n"
         "DISCORD_CHANNEL_AI_NEWS=2\n"
         "DISCORD_CHANNEL_CODE=3\n"
-        "DISCORD_CHANNEL_RESOURCE=4\n",
+        "DISCORD_CHANNEL_RESOURCE=4\n"
+        "DISCORD_CHANNEL_ARXIV=5\n",
         encoding="utf-8",
     )
 
@@ -103,7 +104,7 @@ def test_install_creates_workspace_dirs(cli_mod, tmp_path, monkeypatch):
     from paths import BRIEFINGS_DIR, FRESHRSS_DATA, PUSHED_DIR
 
     assert FRESHRSS_DATA.exists()
-    for cat in ("papers", "ai_news", "code", "resource"):
+    for cat in ("papers", "ai_news", "code", "resource", "arxiv"):
         assert (BRIEFINGS_DIR / cat).is_dir()
         assert (PUSHED_DIR / cat).is_dir()
 


### PR DESCRIPTION
## Summary

Closes #19

将推送时间按内容板块拆分，新增 `arxiv` 独立分类，实现错峰推送。

### 改动内容

- **新增 `arxiv` 分类**：arXiv CS.AI 从 `ai_news` 独立出来，复用 ai_news 的 Discord channel（deeplearning）
- **更新所有硬编码分类列表**：`run_pipelines.py`、`push_to_discord.py`、`cli.py`、`weekly_summary.py`
- **arxiv 推送总结**：与 papers 一样生成推送总结消息
- **周报扫描**：同时扫描 `ai_news/` 和 `arxiv/` 目录

### 推送时间表

| 时间 | 板块 | 内容 |
|------|------|------|
| 6:00 | ai_news + code + resource | AI新闻、GitHub Trending、大工新闻 |
| 7:30 | papers | 期刊论文 |
| 8:30 | arxiv | arXiv CS.AI |

### LaunchAgent 变更

- ~~`ai.dailyinfo.push` (8:30 全推)~~ → 已替换为 3 个独立 plist
- `ai.dailyinfo.push-early` — 6:00
- `ai.dailyinfo.push-papers` — 7:30
- `ai.dailyinfo.push-arxiv` — 8:30

## Test plan

- [x] `uv run pytest` — 138 tests passed
- [x] 手动补推 `--categories ai_news,code,resource` 和 `--categories papers` 成功
- [ ] 明天观察 3 个 LaunchAgent 自动执行情况

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes end-to-end categorization and push behavior (new `arxiv` directory, env var, and push order), which can affect scheduling/dispatch and file routing if misconfigured.
> 
> **Overview**
> Splits arXiv CS.AI into a new **`arxiv` category** (instead of `ai_news`) and propagates that category through the CLI workspace setup, pipeline generation summary, and Discord push orchestration.
> 
> Discord pushing now supports `arxiv` as a daily category, defaults its channel to `ai_news` when unset, and treats `arxiv` like `papers` for per-source push summary messages. Weekly recap generation now aggregates both `ai_news` and `arxiv` briefings, and tests/env validation are updated to require/cover `DISCORD_CHANNEL_ARXIV` and the new workspace directories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 705823fcb8d435eadd4a2f4abcfb2aed94fd66f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->