### PR TITLE
fix: resolve RSS entry duplication and omission via lastSeen + seen-links dedup

### DIFF
--- a/scripts/datasource.py
+++ b/scripts/datasource.py
@@ -263,6 +263,46 @@ class RSSDataSource(DataSource):
             "max_articles_per_batch"
         )
         self.max_batches: int = config.get("max_batches", 1000)
+        self._seen: dict[str, str] = self._load_seen()  # link -> first-seen date
+        self._total_before_filter: int = 0  # for logging
+
+    # --- seen-links dedup ---
+    def _seen_path(self) -> pathlib.Path:
+        return _STATE_DIR / f"{self.name}_seen.json"
+
+    def _load_seen(self) -> dict[str, str]:
+        p = self._seen_path()
+        if p.exists():
+            try:
+                return json.loads(p.read_text(encoding="utf-8"))
+            except Exception:
+                pass
+        return {}
+
+    def _save_seen(self) -> None:
+        _STATE_DIR.mkdir(parents=True, exist_ok=True)
+        self._seen_path().write_text(
+            json.dumps(self._seen, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+    def _filter_seen(self, items: list[Item]) -> list[Item]:
+        self._total_before_filter = len(items)
+        return [it for it in items if it.url not in self._seen]
+
+    def commit_seen(self, items: list[Item]) -> None:
+        """Record item URLs as processed. Called after briefing is saved."""
+        today = datetime.date.today().isoformat()
+        for it in items:
+            if it.url and it.url not in self._seen:
+                self._seen[it.url] = today
+        self._save_seen()
+
+    def cleanup_seen(self, max_age_days: int = 30) -> None:
+        """Remove seen records older than max_age_days."""
+        cutoff = (datetime.date.today() - datetime.timedelta(days=max_age_days)).isoformat()
+        self._seen = {k: v for k, v in self._seen.items() if v >= cutoff}
+        self._save_seen()
 
     def fetch(self) -> list[Item]:
         if not self._db:
@@ -283,7 +323,7 @@ class RSSDataSource(DataSource):
         if self.use_content:
             rows = self._db.execute(
                 "SELECT title, content, link, date FROM entry "
-                "WHERE id_feed=? AND date>? ORDER BY date DESC LIMIT 3",
+                "WHERE id_feed=? AND lastSeen>? ORDER BY date DESC LIMIT 3",
                 [fid, self._cutoff_ts],
             ).fetchall()
             items = []
@@ -306,16 +346,16 @@ class RSSDataSource(DataSource):
                         content=plain,
                     )
                 )
-            return items
+            return self._filter_seen(items)
 
         rows = self._db.execute(
-            "SELECT title, link, date FROM entry WHERE id_feed=? AND date>? ORDER BY date DESC",
+            "SELECT title, link, date FROM entry WHERE id_feed=? AND lastSeen>? ORDER BY date DESC",
             [fid, self._cutoff_ts],
         ).fetchall()
         entries = list(rows)
         if self.max_articles and len(entries) > self.max_articles:
             entries = entries[: self.max_articles]
-        return [
+        items = [
             Item(
                 title=row["title"] or "",
                 date=datetime.datetime.fromtimestamp(row["date"]).strftime("%Y-%m-%d"),
@@ -323,6 +363,7 @@ class RSSDataSource(DataSource):
             )
             for row in entries
         ]
+        return self._filter_seen(items)
 
     def get_batches(self, items: list[Item]) -> list[list[Item]]:
         """Split items into AI-processing batches respecting max_articles_per_batch."""

--- a/scripts/run_pipelines.py
+++ b/scripts/run_pipelines.py
@@ -397,7 +397,9 @@ def run_pipeline_1() -> int:
         model = feed_cfg.get("model") or model_default
 
         if not items:
-            log(f"  {name}: 0 articles — placeholder")
+            log(f"  {name}: 0 new articles — placeholder")
+            ds.commit_seen(items)  # no new items, but record any seen state
+            ds.cleanup_seen()
             placeholder = f"# {ds.display_name} - {DATE}\n\n📭 过去 {ds.lookback_hours} 小时无新内容\n"
             save(category, f"{name}_briefing_{DATE}.md", placeholder)
             saved += 1
@@ -436,10 +438,15 @@ def run_pipeline_1() -> int:
                     time.sleep(1)
                 except Exception as e:
                     log(f"    ERR: {e}")
+            ds.commit_seen(items)
+            ds.cleanup_seen()
             continue
 
         # Regular path — batch by max_articles_per_batch
-        log(f"  {name}: {len(items)} articles")
+        total = ds._total_before_filter
+        new = len(items)
+        dup = total - new
+        log(f"  {name}: {new} new articles" + (f" ({dup} duplicates skipped)" if dup else ""))
         tmpl_key = feed_cfg.get("prompt_template") or default_tmpl_key
         prompt_template = templates.get(tmpl_key) or templates.get(
             "one_line_summary", ""
@@ -471,6 +478,9 @@ def run_pipeline_1() -> int:
                 time.sleep(0.5)
             except Exception as e:
                 log(f"    SAVE ERR: {e}")
+
+        ds.commit_seen(items)
+        ds.cleanup_seen()
 
     db.close()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,7 +84,8 @@ def rss_db():
     conn.execute(
         "CREATE TABLE entry ("
         " id INTEGER PRIMARY KEY AUTOINCREMENT,"
-        " id_feed INTEGER, title TEXT, link TEXT, content TEXT, date INTEGER)"
+        " id_feed INTEGER, title TEXT, link TEXT, content TEXT, date INTEGER,"
+        " lastSeen INTEGER)"
     )
 
     feeds = [
@@ -100,49 +101,53 @@ def rss_db():
     # Feed 1: 5 fresh entries + 1 stale entry
     for i in range(5):
         conn.execute(
-            "INSERT INTO entry(id_feed, title, link, content, date)"
-            " VALUES (?,?,?,?,?)",
+            "INSERT INTO entry(id_feed, title, link, content, date, lastSeen)"
+            " VALUES (?,?,?,?,?,?)",
             (
                 1,
                 f"Fresh Title {i}",
                 f"https://example.com/a/{i}",
                 "",
                 now - i * 60,
+                now - i * 60,
             ),
         )
     conn.execute(
-        "INSERT INTO entry(id_feed, title, link, content, date) VALUES (?,?,?,?,?)",
+        "INSERT INTO entry(id_feed, title, link, content, date, lastSeen) VALUES (?,?,?,?,?,?)",
         (
             1,
             "Stale Title",
             "https://example.com/a/old",
             "",
             now - 48 * 3600,
+            now - 48 * 3600,
         ),
     )
 
     # Feed 3: deep-content entries — one valid, one too-short, one huge.
     conn.execute(
-        "INSERT INTO entry(id_feed, title, link, content, date) VALUES (?,?,?,?,?)",
+        "INSERT INTO entry(id_feed, title, link, content, date, lastSeen) VALUES (?,?,?,?,?,?)",
         (
             3,
             "Deep Normal",
             "https://deep.example.com/a/1",
             "<p>Hello world</p>" + ("abc " * 200),
             now - 30 * 60,
+            now - 30 * 60,
         ),
     )
     conn.execute(
-        "INSERT INTO entry(id_feed, title, link, content, date) VALUES (?,?,?,?,?)",
-        (3, "Deep Short", "https://deep.example.com/a/2", "<p>hi</p>", now - 15 * 60),
+        "INSERT INTO entry(id_feed, title, link, content, date, lastSeen) VALUES (?,?,?,?,?,?)",
+        (3, "Deep Short", "https://deep.example.com/a/2", "<p>hi</p>", now - 15 * 60, now - 15 * 60),
     )
     conn.execute(
-        "INSERT INTO entry(id_feed, title, link, content, date) VALUES (?,?,?,?,?)",
+        "INSERT INTO entry(id_feed, title, link, content, date, lastSeen) VALUES (?,?,?,?,?,?)",
         (
             3,
             "Deep Long",
             "https://deep.example.com/a/3",
             "A" * 20000,
+            now - 10 * 60,
             now - 10 * 60,
         ),
     )


### PR DESCRIPTION
## Summary

Closes #17

解决期刊数据遗漏和重复推送两个问题。

### 问题根因

RSS lookback 过滤器使用 `entry.date`（论文发表日期），导致发表日期较早但刚被 FreshRSS 抓取的论文被遗漏。切换到 `entry.lastSeen` 修复了遗漏问题，但引入了重复——FreshRSS 每次刷新都会更新 `lastSeen`，导致已处理过的论文被重复抓取。

### 解决方案：lastSeen + seen-links 双重机制

1. **用 `lastSeen` 替代 `date` 做过滤** — 不漏：刚入库的论文无论发表日期多久前都能被抓到
2. **per-source seen-links 状态文件** — 不重：记录每个源已处理过的条目 URL，重复条目自动跳过

### 改动内容

- **`datasource.py`** — RSSDataSource 新增 seen-links 机制：
  - `_load_seen()` / `_save_seen()`: 读写 `state/{name}_seen.json`
  - `_filter_seen()`: 过滤已处理条目
  - `commit_seen()`: briefing 保存后记录新条目 URL
  - `cleanup_seen()`: 清理 30 天前的旧记录
  - `fetch()`: 两处 SQL 改用 `lastSeen` 过滤 + `_filter_seen()` 去重
  - 日志显示去重统计："8 new articles (12 duplicates skipped)"

- **`run_pipelines.py`** — 集成 commit_seen：
  - placeholder / deep-content / regular 三条路径后都调用 `commit_seen()` + `cleanup_seen()`
  - 恢复 `_already_pushed_within` 的 `lookback_hours > 24` 条件（仅用于非 RSS 源）

- **`conftest.py`** — 测试数据库添加 `lastSeen` 列

### 验证结果

- 强制重跑 pipeline 1（`-f all`）：大部分源显示 `0 new articles`（旧论文被 seen 过滤），只有真正有新论文的源生成 briefing
- 运行时间从 10 小时（116 文件含大量重复）降至 10 分钟（6 个实质文件）
- 138 个测试全部通过

## Test plan

- [x] `uv run pytest` — 138 passed
- [x] 强制重跑 pipeline 1，验证 seen-filter 去重效果
- [x] 确认 `state/*_seen.json` 文件正确生成和更新
- [ ] 观察连续两天的自动运行，确认无遗漏无重复

🤖 Generated with [Claude Code](https://claude.com/claude-code)