### PR TITLE
fix: AI generation failure degradation + merge batch files

### DIFF
--- a/scripts/run_pipelines.py
+++ b/scripts/run_pipelines.py
@@ -298,6 +298,122 @@ def save(directory: str, filename: str, content: str) -> str:
     return str(full)
 
 
+def _make_placeholder_briefing(ds, items: list) -> str:
+    """Generate a placeholder briefing with titles and links for items that
+    failed AI generation. These items are still committed to seen to prevent
+    unbounded accumulation across retries."""
+    lines = [f"# {ds.display_name} - {DATE}\n"]
+    lines.append("⚠️ 以下文章 AI 摘要生成失败，仅保留标题和链接：\n")
+    for idx, item in enumerate(items, 1):
+        url_part = f"  [查看原文]({item.url})" if item.url else ""
+        lines.append(f"{idx}. **{item.title}**\n{url_part}")
+    return "\n".join(lines)
+
+
+def _retry_failed_items(
+    ds,
+    failed_items: list,
+    prompt_template: str,
+    model: str,
+) -> list[tuple[str, list]]:
+    """Phase 2: retry failed items with smaller batches and more tokens.
+
+    Returns list of (content, batch_items) tuples. Items that still fail
+    after Phase 2 are returned with an empty batch_items list and
+    placeholder content so the caller can commit them to seen.
+    """
+    if not failed_items:
+        return []
+    log(
+        f"    Phase 2: retrying {len(failed_items)} failed articles "
+        f"with conservative settings (batch=3, max_tokens=4000)"
+    )
+    results: list[tuple[str, list]] = []
+    batch_size = 3
+    for i in range(0, len(failed_items), batch_size):
+        batch = failed_items[i : i + batch_size]
+        try:
+            results.extend(
+                _generate_regular_briefings(
+                    ds, batch, prompt_template, model, max_tokens=4000
+                )
+            )
+        except Exception as e:
+            log(f"    Phase 2 retry failed for {len(batch)} articles: {e}")
+            placeholder = _make_placeholder_briefing(ds, batch)
+            results.append((placeholder, batch))  # batch kept for commit_seen
+    return results
+
+
+# Regex patterns for parsing AI-generated briefing parts
+_RE_HEADER = re.compile(r"^## 📚 .+$", re.MULTILINE)
+_RE_HIGHLIGHT = re.compile(r"\n🔭 \*\*Today's? Highlight\*\*", re.IGNORECASE)
+_RE_NUMBERED = re.compile(r"^(\d+)\.\s+\*\*", re.MULTILINE)
+
+
+def _merge_briefing_parts(
+    ds, parts: list[tuple[str, list]]
+) -> tuple[str, list]:
+    """Merge multiple briefing parts into one cohesive document.
+
+    Strips per-batch headers, renumbers articles sequentially, and
+    collects highlight sections at the end.
+
+    Returns (merged_content, all_items).
+    """
+    if not parts:
+        return "", []
+    if len(parts) == 1:
+        return parts[0]
+
+    all_items: list = []
+    article_blocks: list[str] = []
+    highlight_blocks: list[str] = []
+
+    for content, items in parts:
+        all_items.extend(items)
+
+        # Split content at the highlight section
+        hl_match = _RE_HIGHLIGHT.search(content)
+        if hl_match:
+            article_part = content[: hl_match.start()]
+            highlight_part = content[hl_match.start() :].strip()
+            highlight_blocks.append(highlight_part)
+        else:
+            article_part = content
+            # Also check for placeholder-style content (no highlight)
+
+        # Remove per-batch header line (## 📚 ...)
+        article_part = _RE_HEADER.sub("", article_part).strip()
+
+        # Renumber articles sequentially
+        current_num = len(all_items) - len(items)
+        def _renumber(m):
+            nonlocal current_num
+            current_num += 1
+            return f"{current_num}. **"
+        article_part = _RE_NUMBERED.sub(_renumber, article_part)
+
+        if article_part:
+            article_blocks.append(article_part)
+
+    # Build merged content
+    total = len(all_items)
+    header = f"## 📚 {ds.display_name} 今日简报 ({DATE}) - {total}篇文章"
+    merged = header + "\n\n"
+    merged += "\n\n".join(article_blocks)
+
+    if highlight_blocks:
+        merged += "\n\n"
+        if len(highlight_blocks) == 1:
+            merged += highlight_blocks[0]
+        else:
+            merged += "🔭 **今日研究亮点汇总**\n\n"
+            merged += "\n\n---\n\n".join(highlight_blocks)
+
+    return merged, all_items
+
+
 def _already_pushed_within(name: str, category: str, lookback_hours: int) -> bool:
     """Return True if this source already produced a pushed briefing recently.
 
@@ -423,6 +539,7 @@ def run_pipeline_1() -> int:
             tmpl_key = feed_cfg.get("prompt_template", "smolai_categorized")
             tmpl = templates.get(tmpl_key, "")
             committed_items: list = []
+            failed_items: list = []
             for idx, item in enumerate(items):
                 prompt = (
                     tmpl.replace("{content}", item.content).replace("{date}", DATE)
@@ -444,6 +561,32 @@ def run_pipeline_1() -> int:
                     time.sleep(1)
                 except Exception as e:
                     log(f"    ERR: {e}")
+                    failed_items.append(item)
+
+            # Retry failed deep-content items once, then placeholder fallback
+            if failed_items:
+                log(f"    Phase 2: retrying {len(failed_items)} failed deep-content articles")
+                for retry_idx, item in enumerate(failed_items, start=1):
+                    prompt = (
+                        tmpl.replace("{content}", item.content).replace("{date}", DATE)
+                        if tmpl
+                        else f"Summarize the following AI news in Chinese by category:\n\n{item.content}"
+                    )
+                    try:
+                        content_text = call_ai(prompt, model=model, max_tokens=3000)
+                        filename = f"{name}_briefing_{DATE}_retry{retry_idx}.md"
+                        save(category, filename, f"# AI Daily Digest - {DATE}\n\n{content_text}")
+                        saved += 1
+                        committed_items.append(item)
+                        log(f"    -> saved retry {filename}")
+                    except Exception as e:
+                        log(f"    Phase 2 retry failed: {e} → placeholder")
+                        placeholder = _make_placeholder_briefing(ds, [item])
+                        filename = f"{name}_briefing_{DATE}_failed{retry_idx}.md"
+                        save(category, filename, placeholder)
+                        saved += 1
+                        committed_items.append(item)  # commit even placeholder items
+
             ds.commit_seen(committed_items)
             ds.cleanup_seen()
             continue
@@ -462,6 +605,7 @@ def run_pipeline_1() -> int:
             continue
 
         generated_parts: list[tuple[str, list]] = []
+        failed_items: list = []
         batches = ds.get_batches(items)
         for idx, batch in enumerate(batches):
             try:
@@ -470,24 +614,27 @@ def run_pipeline_1() -> int:
                 )
             except Exception as e:
                 log(f"    ERR batch {idx + 1}: {e}")
+                failed_items.extend(batch)
 
-        should_suffix = (
-            bool(feed_cfg.get("max_articles_per_batch")) or len(generated_parts) > 1
-        )
-        committed_items: list = []
-        for part_idx, (content_text, batch_items) in enumerate(generated_parts, start=1):
-            suffix = f"_batch{part_idx}" if should_suffix else ""
-            filename = f"{name}_briefing_{DATE}{suffix}.md"
+        # Phase 2: retry failed items with conservative settings
+        if failed_items:
+            phase2_parts = _retry_failed_items(
+                ds, failed_items, prompt_template, model
+            )
+            generated_parts.extend(phase2_parts)
+
+        # Merge all parts into one cohesive briefing
+        merged_content, all_items = _merge_briefing_parts(ds, generated_parts)
+        if merged_content:
+            filename = f"{name}_briefing_{DATE}.md"
             try:
-                save(category, filename, content_text)
+                save(category, filename, merged_content)
                 saved += 1
-                committed_items.extend(batch_items)
                 log(f"    -> saved {filename}")
-                time.sleep(0.5)
             except Exception as e:
                 log(f"    SAVE ERR: {e}")
 
-        ds.commit_seen(committed_items)
+        ds.commit_seen(all_items)
         ds.cleanup_seen()
 
     db.close()
@@ -542,6 +689,7 @@ def run_pipeline_1() -> int:
             continue
 
         generated_parts: list[tuple[str, list]] = []
+        failed_items: list = []
         for idx, batch in enumerate(ds.get_batches(items)):
             try:
                 generated_parts.extend(
@@ -549,16 +697,23 @@ def run_pipeline_1() -> int:
                 )
             except Exception as e:
                 log(f"    ERR batch {idx + 1}: {e}")
+                failed_items.extend(batch)
 
-        should_suffix = bool(source_cfg.get("max_articles_per_batch")) or len(generated_parts) > 1
-        for part_idx, (content_text, _batch_items) in enumerate(generated_parts, start=1):
-            suffix = f"_batch{part_idx}" if should_suffix else ""
-            filename = f"{name}_briefing_{DATE}{suffix}.md"
+        # Phase 2: retry failed items
+        if failed_items:
+            phase2_parts = _retry_failed_items(
+                ds, failed_items, prompt_template, model
+            )
+            generated_parts.extend(phase2_parts)
+
+        # Merge all parts into one cohesive briefing
+        merged_content, _all_items = _merge_briefing_parts(ds, generated_parts)
+        if merged_content:
+            filename = f"{name}_briefing_{DATE}.md"
             try:
-                save(category, filename, content_text)
+                save(category, filename, merged_content)
                 saved += 1
                 log(f"    -> saved {filename}")
-                time.sleep(0.5)
             except Exception as e:
                 log(f"    SAVE ERR: {e}")
 

--- a/scripts/run_pipelines.py
+++ b/scripts/run_pipelines.py
@@ -259,8 +259,12 @@ def _generate_regular_briefings(
     model: str,
     *,
     max_tokens: int = 2500,
-) -> list[str]:
-    """Generate one or more complete briefings, splitting oversized batches."""
+) -> list[tuple[str, list]]:
+    """Generate one or more complete briefings, splitting oversized batches.
+
+    Returns list of (content, batch_items) tuples so callers can track which
+    items were successfully processed for commit_seen.
+    """
     prompt = _build_regular_prompt(prompt_template, ds, batch)
     try:
         content = call_ai(prompt, model=model, max_tokens=max_tokens)
@@ -269,7 +273,7 @@ def _generate_regular_briefings(
             f"    AI ok: source={ds.name}, articles={len(batch)}, "
             f"prompt_chars={len(prompt)}, response_chars={len(content)}"
         )
-        return [content]
+        return [(content, batch)]
     except BriefingGenerationError as exc:
         if len(batch) <= 1:
             raise
@@ -418,6 +422,7 @@ def run_pipeline_1() -> int:
             log(f"  {name}: {len(items)} articles (deep content)")
             tmpl_key = feed_cfg.get("prompt_template", "smolai_categorized")
             tmpl = templates.get(tmpl_key, "")
+            committed_items: list = []
             for idx, item in enumerate(items):
                 prompt = (
                     tmpl.replace("{content}", item.content).replace("{date}", DATE)
@@ -434,11 +439,12 @@ def run_pipeline_1() -> int:
                         f"# AI Daily Digest - {DATE}\n\n{content_text}",
                     )
                     saved += 1
+                    committed_items.append(item)
                     log(f"    -> saved {filename}")
                     time.sleep(1)
                 except Exception as e:
                     log(f"    ERR: {e}")
-            ds.commit_seen(items)
+            ds.commit_seen(committed_items)
             ds.cleanup_seen()
             continue
 
@@ -455,7 +461,7 @@ def run_pipeline_1() -> int:
             log(f"  SKIP {name}: no prompt template")
             continue
 
-        generated_parts: list[str] = []
+        generated_parts: list[tuple[str, list]] = []
         batches = ds.get_batches(items)
         for idx, batch in enumerate(batches):
             try:
@@ -468,18 +474,20 @@ def run_pipeline_1() -> int:
         should_suffix = (
             bool(feed_cfg.get("max_articles_per_batch")) or len(generated_parts) > 1
         )
-        for part_idx, content_text in enumerate(generated_parts, start=1):
+        committed_items: list = []
+        for part_idx, (content_text, batch_items) in enumerate(generated_parts, start=1):
             suffix = f"_batch{part_idx}" if should_suffix else ""
             filename = f"{name}_briefing_{DATE}{suffix}.md"
             try:
                 save(category, filename, content_text)
                 saved += 1
+                committed_items.extend(batch_items)
                 log(f"    -> saved {filename}")
                 time.sleep(0.5)
             except Exception as e:
                 log(f"    SAVE ERR: {e}")
 
-        ds.commit_seen(items)
+        ds.commit_seen(committed_items)
         ds.cleanup_seen()
 
     db.close()
@@ -533,7 +541,7 @@ def run_pipeline_1() -> int:
             log(f"    SKIP {name}: no prompt template")
             continue
 
-        generated_parts: list[str] = []
+        generated_parts: list[tuple[str, list]] = []
         for idx, batch in enumerate(ds.get_batches(items)):
             try:
                 generated_parts.extend(
@@ -543,7 +551,7 @@ def run_pipeline_1() -> int:
                 log(f"    ERR batch {idx + 1}: {e}")
 
         should_suffix = bool(source_cfg.get("max_articles_per_batch")) or len(generated_parts) > 1
-        for part_idx, content_text in enumerate(generated_parts, start=1):
+        for part_idx, (content_text, _batch_items) in enumerate(generated_parts, start=1):
             suffix = f"_batch{part_idx}" if should_suffix else ""
             filename = f"{name}_briefing_{DATE}{suffix}.md"
             try:

--- a/tests/test_datasource_rss.py
+++ b/tests/test_datasource_rss.py
@@ -165,3 +165,103 @@ def test_fetch_no_db_returns_empty():
         db=None,
     )
     assert ds.fetch() == []
+
+
+def test_seen_dedup_filters_already_processed(rss_db):
+    """Items whose URLs are already in seen should be filtered out."""
+    ds = _make_rss(
+        {
+            "name": "test_feed1",
+            "type": "rss",
+            "category": "papers",
+            "url": "https://example.com/feed.xml",
+        },
+        rss_db,
+    )
+    # First fetch returns all fresh items
+    items = ds.fetch()
+    assert len(items) == 5
+
+    # Mark all as seen
+    ds.commit_seen(items)
+    assert len(ds._seen) == 5
+
+    # Second fetch should filter all of them out
+    items2 = ds.fetch()
+    assert items2 == []
+
+
+def test_commit_seen_only_records_provided_items(rss_db):
+    """commit_seen should only mark the items passed to it, not all fetched items."""
+    from datasource import Item
+
+    ds = _make_rss(
+        {
+            "name": "test_feed1",
+            "type": "rss",
+            "category": "papers",
+            "url": "https://example.com/feed.xml",
+        },
+        rss_db,
+    )
+    items = ds.fetch()
+    assert len(items) == 5
+
+    # Only commit first 2 items (simulating partial success)
+    ds.commit_seen(items[:2])
+    assert len(ds._seen) == 2
+
+    # Re-fetch: 3 uncommitted items should come through
+    items2 = ds.fetch()
+    assert len(items2) == 3
+
+
+def test_commit_seen_empty_list_is_harmless(rss_db):
+    """commit_seen([]) should not fail and should not affect existing seen state."""
+    from datasource import Item
+
+    ds = _make_rss(
+        {
+            "name": "test_feed1",
+            "type": "rss",
+            "category": "papers",
+            "url": "https://example.com/feed.xml",
+        },
+        rss_db,
+    )
+    items = ds.fetch()
+    ds.commit_seen(items[:1])
+    assert len(ds._seen) == 1
+
+    ds.commit_seen([])  # no-op
+    assert len(ds._seen) == 1
+
+
+def test_cleanup_seen_removes_old_entries(rss_db):
+    """cleanup_seen should remove entries older than max_age_days."""
+    from datasource import Item
+
+    ds = _make_rss(
+        {
+            "name": "test_feed1",
+            "type": "rss",
+            "category": "papers",
+            "url": "https://example.com/feed.xml",
+        },
+        rss_db,
+    )
+    # Manually add old + new entries to seen
+    ds._seen = {
+        "https://old.com/1": "2026-04-01",
+        "https://old.com/2": "2026-04-10",
+        "https://new.com/1": "2026-05-12",
+    }
+    ds._save_seen()
+
+    ds.cleanup_seen(max_age_days=30)
+    # 2026-04-01 is 42 days before 2026-05-13 → removed
+    # 2026-04-10 is 33 days before → removed
+    # 2026-05-12 is 1 day before → kept
+    assert "https://old.com/1" not in ds._seen
+    assert "https://old.com/2" not in ds._seen
+    assert "https://new.com/1" in ds._seen

--- a/tests/test_run_pipelines.py
+++ b/tests/test_run_pipelines.py
@@ -484,6 +484,243 @@ def test_generate_regular_briefings_returns_batch_items_for_tracking(monkeypatch
     assert len(all_items) == 4
 
 
+def test_make_placeholder_briefing_format():
+    """Placeholder briefing contains titles and links for failed items."""
+    import run_pipelines as rp
+    from datasource import Item, RSSDataSource
+
+    ds = RSSDataSource(
+        {"name": "test_ph", "display_name": "Test Placeholder", "category": "papers"},
+        {"lookback_hours": 24},
+    )
+    items = [
+        Item(title="Alpha Paper", date="2026-04-25", url="https://doi.org/10.1/a"),
+        Item(title="Beta Paper", date="2026-04-25", url="https://doi.org/10.1/b"),
+    ]
+
+    result = rp._make_placeholder_briefing(ds, items)
+    assert "Test Placeholder" in result
+    assert "⚠️" in result
+    assert "Alpha Paper" in result
+    assert "Beta Paper" in result
+    assert "https://doi.org/10.1/a" in result
+    assert "https://doi.org/10.1/b" in result
+
+
+def test_make_placeholder_briefing_handles_no_url():
+    """Items without a URL should not crash the placeholder generator."""
+    import run_pipelines as rp
+    from datasource import Item, RSSDataSource
+
+    ds = RSSDataSource(
+        {"name": "no_url", "display_name": "No URL", "category": "papers"},
+        {"lookback_hours": 24},
+    )
+    items = [Item(title="No Link", date="2026-04-25")]
+    result = rp._make_placeholder_briefing(ds, items)
+    assert "No Link" in result
+    assert "查看原文" not in result
+
+
+def test_retry_failed_items_succeeds_on_second_try(monkeypatch):
+    """Phase 2 retries failed items with smaller batches; items that succeed
+    on retry should be returned with their batch_items."""
+    import run_pipelines as rp
+    from datasource import Item, RSSDataSource
+
+    ds = RSSDataSource(
+        {"name": "retry_ok", "display_name": "Retry OK", "category": "papers"},
+        {"lookback_hours": 24},
+    )
+    failed_items = [
+        Item(title=f"Failed {i}", date="2026-04-25", url=f"https://doi.org/f{i}")
+        for i in range(3)
+    ]
+
+    call_count = 0
+
+    def fake_call_ai(prompt, model="stub", max_tokens=0, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        count = prompt.count(". Failed")
+        return "\n\n".join(f"{i+1}. **Failed {i}**\n   > 摘要。" for i in range(count))
+
+    monkeypatch.setattr(rp, "call_ai", fake_call_ai)
+    monkeypatch.setattr(rp, "log", lambda *_: None)
+
+    results = rp._retry_failed_items(
+        ds, failed_items,
+        "请总结 {count} 篇 {display_name}：\n{article_list}\n{date}",
+        "stub",
+    )
+
+    assert len(results) == 1
+    content, batch_items = results[0]
+    assert len(batch_items) == 3
+    assert "Failed 0" in content
+
+
+def test_retry_failed_items_falls_back_to_placeholder(monkeypatch):
+    """Phase 2 items that still fail should get placeholder content,
+    and their batch_items should still be returned for commit_seen."""
+    import run_pipelines as rp
+    from datasource import Item, RSSDataSource
+
+    ds = RSSDataSource(
+        {"name": "retry_fail", "display_name": "Retry Fail", "category": "papers"},
+        {"lookback_hours": 24},
+    )
+    failed_items = [
+        Item(title=f"Lost {i}", date="2026-04-25", url=f"https://doi.org/l{i}")
+        for i in range(2)
+    ]
+
+    def fake_call_ai(prompt, model="stub", max_tokens=0, **kwargs):
+        raise rp.BriefingGenerationError("always fails")
+
+    monkeypatch.setattr(rp, "call_ai", fake_call_ai)
+    logs = []
+    monkeypatch.setattr(rp, "log", lambda msg: logs.append(msg))
+
+    results = rp._retry_failed_items(
+        ds, failed_items,
+        "请总结 {count} 篇 {display_name}：\n{article_list}\n{date}",
+        "stub",
+    )
+
+    assert len(results) == 1
+    content, batch_items = results[0]
+    assert "⚠️" in content  # placeholder
+    assert "Lost 0" in content
+    assert len(batch_items) == 2  # returned for commit_seen
+
+
+def test_retry_failed_items_returns_empty_for_no_failures():
+    """No failed items → empty result, no AI calls."""
+    import run_pipelines as rp
+    from datasource import RSSDataSource
+
+    ds = RSSDataSource(
+        {"name": "empty", "display_name": "Empty", "category": "papers"},
+        {"lookback_hours": 24},
+    )
+    results = rp._retry_failed_items(ds, [], "template", "model")
+    assert results == []
+
+
+def test_merge_briefing_parts_single_part_passthrough():
+    """A single part should be returned as-is."""
+    import run_pipelines as rp
+    from datasource import Item, RSSDataSource
+
+    ds = RSSDataSource(
+        {"name": "single", "display_name": "Single Source", "category": "papers"},
+        {"lookback_hours": 24},
+    )
+    content = "## 📚 Single Source 今日简报 (2026-05-14) - 2篇文章\n\n1. **A**\n2. **B**"
+    items = [Item(title="A", date="2026-05-14"), Item(title="B", date="2026-05-14")]
+
+    merged, all_items = rp._merge_briefing_parts(ds, [(content, items)])
+    assert merged == content
+    assert all_items == items
+
+
+def test_merge_briefing_parts_empty_returns_empty():
+    """No parts → empty string and empty list."""
+    import run_pipelines as rp
+    from datasource import RSSDataSource
+
+    ds = RSSDataSource(
+        {"name": "empty", "display_name": "Empty", "category": "papers"},
+        {"lookback_hours": 24},
+    )
+    merged, all_items = rp._merge_briefing_parts(ds, [])
+    assert merged == ""
+    assert all_items == []
+
+
+def test_merge_briefing_parts_merges_multiple_parts():
+    """Multiple parts should be merged with one header, sequential numbering,
+    and collected highlights."""
+    import run_pipelines as rp
+    from datasource import Item, RSSDataSource
+
+    ds = RSSDataSource(
+        {"name": "multi", "display_name": "Multi Source", "category": "papers"},
+        {"lookback_hours": 24},
+    )
+
+    part1_content = (
+        "## 📚 Multi Source 今日简报 (2026-05-14) - 2篇文章\n\n"
+        "1. **Alpha**\n   > 摘要A\n\n"
+        "2. **Beta**\n   > 摘要B\n\n"
+        "🔭 **Today's Highlight**\n亮点1"
+    )
+    part2_content = (
+        "## 📚 Multi Source 今日简报 (2026-05-14) - 2篇文章\n\n"
+        "1. **Gamma**\n   > 摘要C\n\n"
+        "2. **Delta**\n   > 摘要D\n\n"
+        "🔭 **Today's Highlight**\n亮点2"
+    )
+    items1 = [Item(title="Alpha", date="2026-05-14"), Item(title="Beta", date="2026-05-14")]
+    items2 = [Item(title="Gamma", date="2026-05-14"), Item(title="Delta", date="2026-05-14")]
+
+    merged, all_items = rp._merge_briefing_parts(
+        ds, [(part1_content, items1), (part2_content, items2)]
+    )
+
+    # Should have one header with total count
+    assert "4篇文章" in merged
+    assert merged.count("## 📚") == 1  # only one header
+
+    # Articles should be renumbered 1-4
+    assert "1. **Alpha**" in merged
+    assert "2. **Beta**" in merged
+    assert "3. **Gamma**" in merged
+    assert "4. **Delta**" in merged
+
+    # Should NOT have duplicate "1." entries
+    assert merged.count("1. **") == 1
+
+    # Highlights should be collected
+    assert "亮点1" in merged
+    assert "亮点2" in merged
+
+    # All items returned
+    assert len(all_items) == 4
+
+
+def test_merge_briefing_parts_without_highlights():
+    """Parts without highlights (e.g. placeholder content) should still merge."""
+    import run_pipelines as rp
+    from datasource import Item, RSSDataSource
+
+    ds = RSSDataSource(
+        {"name": "no_hl", "display_name": "No Highlight", "category": "papers"},
+        {"lookback_hours": 24},
+    )
+
+    part1 = (
+        "## 📚 No Highlight 今日简报 (2026-05-14) - 1篇文章\n\n"
+        "1. **Paper A**\n   > 摘要"
+    )
+    part2 = (
+        "## 📚 No Highlight 今日简报 (2026-05-14) - 1篇文章\n\n"
+        "1. **Paper B**\n   > 摘要"
+    )
+    items1 = [Item(title="Paper A", date="2026-05-14")]
+    items2 = [Item(title="Paper B", date="2026-05-14")]
+
+    merged, all_items = rp._merge_briefing_parts(
+        ds, [(part1, items1), (part2, items2)]
+    )
+
+    assert "2篇文章" in merged
+    assert "1. **Paper A**" in merged
+    assert "2. **Paper B**" in merged
+    assert len(all_items) == 2
+
+
 def _make_dlut_news_sources_json(path, templates_extra=None):
     """Write a minimal sources.json with two dlut_news group sources + one recruitment source."""
     from datetime import datetime

--- a/tests/test_run_pipelines.py
+++ b/tests/test_run_pipelines.py
@@ -445,6 +445,43 @@ def test_generate_regular_briefings_splits_incomplete_batch(monkeypatch):
 
     assert calls == [4, 2, 2]
     assert len(out) == 2
+    # Each element is now (content, batch_items) tuple
+    for content, batch_items in out:
+        assert isinstance(content, str)
+        assert isinstance(batch_items, list)
+
+
+def test_generate_regular_briefings_returns_batch_items_for_tracking(monkeypatch):
+    """_generate_regular_briefings returns (content, batch_items) so callers
+    can commit_seen only for successfully processed items."""
+    import run_pipelines as rp
+    from datasource import Item, RSSDataSource
+
+    ds = RSSDataSource(
+        {"name": "track_test", "display_name": "Track", "category": "papers"},
+        {"lookback_hours": 24},
+    )
+    batch_a = [Item(title=f"Paper {i}", date="2026-04-25") for i in range(2)]
+    batch_b = [Item(title=f"Paper {i}", date="2026-04-25") for i in range(2, 4)]
+
+    def fake_call_ai(prompt, model="stub", max_tokens=0, **kwargs):
+        return "1. **Paper A**\n   > 摘要。\n\n2. **Paper B**\n   > 摘要。"
+
+    monkeypatch.setattr(rp, "call_ai", fake_call_ai)
+    monkeypatch.setattr(rp, "log", lambda *_: None)
+
+    out = rp._generate_regular_briefings(
+        ds,
+        batch_a + batch_b,
+        "请总结 {count} 篇 {display_name}：\n{article_list}\n{date}",
+        "stub",
+    )
+
+    # All items should be tracked in their respective tuples
+    all_items = []
+    for content, batch_items in out:
+        all_items.extend(batch_items)
+    assert len(all_items) == 4
 
 
 def _make_dlut_news_sources_json(path, templates_extra=None):


### PR DESCRIPTION
## Summary

Fixes #29

- **Two-phase retry**: Failed AI batches are retried with conservative settings (batch=3, max_tokens=4000) before giving up
- **Placeholder fallback**: Items that still fail after Phase 2 get a placeholder briefing (title + link), ensuring no article is silently lost. These items are committed to seen to prevent unbounded accumulation
- **Merge batch files**: All generated parts for a source are merged into a single file with one header, sequential article numbering, and collected highlights. Eliminates `_batch{N}` fragment files
- **Selective commit_seen**: Only successfully briefed items are committed to seen (from previous commit 49566fe)

## Test plan

- [x] `uv run pytest` — 152 passed
- [x] `dailyinfo run -p 1` — verified Nature, arxiv etc. generate single merged files
- [x] `dailyinfo push` — verified single-file push works correctly, Discord message chunking handles long content
- [x] Observed Phase 2 retry triggering in production logs for james source
- [x] Verified seen files correctly record all processed URLs, no duplicate generation next day

🤖 Generated with [Claude Code](https://claude.com/claude-code)