### PR TITLE
fix: process ai_news/arxiv before papers in pipeline 1

### DIFF
--- a/scripts/run_pipelines.py
+++ b/scripts/run_pipelines.py
@@ -498,9 +498,16 @@ def run_pipeline_1() -> int:
     full_map, base_map = build_feed_url_map(db)
     saved = 0
 
-    for feed_cfg in cfg["sources"]:
-        if feed_cfg.get("type") != "rss" or not feed_cfg.get("enabled", True):
-            continue
+    # Process RSS sources in category priority order so that ai_news (6:00 push)
+    # and arxiv (8:30 push) are generated before papers (7:30 push).
+    _CATEGORY_PRIORITY = {"ai_news": 0, "arxiv": 1, "papers": 2}
+    rss_sources = [
+        s for s in cfg["sources"]
+        if s.get("type") == "rss" and s.get("enabled", True)
+    ]
+    rss_sources.sort(key=lambda s: _CATEGORY_PRIORITY.get(s.get("category"), 9))
+
+    for feed_cfg in rss_sources:
 
         ds = DataSource.create(
             feed_cfg, defaults, db=db, full_map=full_map, base_map=base_map


### PR DESCRIPTION
## Summary

Fixes #31

RSS sources in pipeline 1 were processed in config order, meaning smolai_news (ai_news) was the 34th source — after all 33 paper sources. This caused it to be generated too late for the 6:00 early push.

Now RSS sources are sorted by category priority before processing:
- `ai_news` first (6:00 push)
- `arxiv` second (8:30 push)  
- `papers` last (7:30 push)

This ensures ai_news content is always ready before its push deadline.

## Test plan

- [x] `uv run pytest` — 152 passed
- [ ] Tomorrow's 5:00 pipeline run should show smolai_news processed before papers sources in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)