### PR TITLE
chore: switch AI model from OpenRouter Kimi K2.5 to DeepSeek V4 Pro API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,13 @@
 # DailyInfo Configuration
 # Copy this file to .env and fill in your API keys
 
-# OpenRouter API Key (required for AI summarization)
+# DeepSeek API Key (required — primary AI model: deepseek-v4-pro)
+# Get at: https://platform.deepseek.com/api_keys
+DEEPSEEK_API_KEY=sk-your_deepseek_key_here
+
+# OpenRouter API Key (optional — only needed for fallback to moonshotai/kimi-k2.5)
 # Get at: https://openrouter.ai/keys
-OPENROUTER_API_KEY=sk-or-v1-your_key_here
+# OPENROUTER_API_KEY=sk-or-v1-your_key_here
 
 # Discord Bot Token (required for `dailyinfo push`)
 # Get at: https://discord.com/developers/applications
@@ -13,6 +17,7 @@ DISCORD_BOT_TOKEN=your_discord_bot_token_here
 # category to be skipped at push time (not a fatal error).
 DISCORD_CHANNEL_PAPERS=
 DISCORD_CHANNEL_AI_NEWS=
+DISCORD_CHANNEL_ARXIV=
 DISCORD_CHANNEL_CODE=
 DISCORD_CHANNEL_RESOURCE=
 
@@ -27,6 +32,6 @@ FRESHRSS_PASSWORD=freshrss123
 DAILYINFO_DATA_ROOT=
 
 # Fallback AI model (optional)
-# Used by `dailyinfo run` when the primary model returns empty responses after
-# retries. Any OpenRouter model slug works. Default: deepseek/deepseek-chat-v3.1
+# Used when DeepSeek V4 Pro returns empty responses after retries.
+# The fallback routes through OpenRouter. Default: moonshotai/kimi-k2.5
 # DAILYINFO_FALLBACK_MODEL=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@
 
 - **RSS 聚合**：FreshRSS（Docker + SQLite）
 - **处理引擎**：`scripts/run_pipelines.py`（Python, 宿主机直接运行）
-- **AI 模型**：OpenRouter（moonshotai/kimi-k2.5）
+- **AI 模型**：DeepSeek V4 Pro 官方 API（回退：OpenRouter moonshotai/kimi-k2.5）
 - **推送脚本**：`scripts/push_to_discord.py`（纯 Python requests，无 AI 调用）
 - **容器编排**：Docker Compose（仅 FreshRSS）
 
@@ -77,7 +77,7 @@ python3 -c "import json; json.load(open('config/sources.json'))"
 {
   "version": 2,
   "defaults": {
-    "model": "moonshotai/kimi-k2.5",
+    "model": "deepseek-v4-pro",
     "lookback_hours": 24
   },
   "sources": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-DailyInfo is an automated research intelligence aggregation and push system for AI for Science researchers. It collects RSS feeds, scrapes websites, and queries APIs, then uses OpenRouter LLMs to generate Chinese-language summaries pushed to Discord channels.
+DailyInfo is an automated research intelligence aggregation and push system for AI for Science researchers. It collects RSS feeds, scrapes websites, and queries APIs, then uses DeepSeek V4 Pro (OpenRouter Kimi K2.5 as fallback) to generate Chinese-language summaries pushed to Discord channels.
 
 **Core pipeline**: FreshRSS collection -> AI summary generation (markdown to disk) -> Discord push + archive
 
@@ -15,7 +15,7 @@ DailyInfo is an automated research intelligence aggregation and push system for 
 - Python 3.10+, package manager: uv (primary) / pip (fallback)
 - CLI: Click 8+
 - RSS: FreshRSS (Docker/SQLite, `restart: always`, auto-start via myopenclaw launchd)
-- AI: OpenRouter API (primary: `moonshotai/kimi-k2.5`, fallback: `deepseek/deepseek-chat-v3.1`)
+- AI: DeepSeek V4 Pro official API (fallback: OpenRouter `moonshotai/kimi-k2.5`)
 - Push: Discord Bot API via `requests`
 - Paper download: `dailyinfo_fetcher/` (async httpx + browser agents; `uv sync --extra paper`)
 - Docs: MkDocs Material (GitHub Pages)
@@ -81,7 +81,7 @@ Each pipeline is independent — a failure in one does not affect the others. Co
 ### Data Flow
 
 1. **Collection**: FreshRSS for RSS; `datasource.py` handles scraping/API
-2. **Processing** (`run_pipelines.py`): Fetch -> format -> call OpenRouter AI with prompt templates -> save markdown to `~/.myagentdata/dailyinfo/briefings/{category}/`
+2. **Processing** (`run_pipelines.py`): Fetch -> format -> call DeepSeek AI with prompt templates -> save markdown to `~/.myagentdata/dailyinfo/briefings/{category}/`
 3. **Push** (`push_to_discord.py`): Scan briefings -> POST to Discord channels -> move to `pushed/{category}/`
 
 ### DataSource Class Hierarchy
@@ -108,7 +108,7 @@ Each pipeline is independent — a failure in one does not affect the others. Co
 
 Sources in `config/sources.json` have types: `rss`, `api`, `scrape`. Categories: `papers`, `ai_news`, `code`, `resource`.
 
-Defaults (all overridable per-source): `lookback_hours: 24`, `max_articles_per_batch: 10`, `model: moonshotai/kimi-k2.5`.
+Defaults (all overridable per-source): `lookback_hours: 24`, `max_articles_per_batch: 10`, `model: deepseek-v4-pro`.
 
 Prompt templates under `prompt_templates` key use placeholders: `{count}`, `{display_name}`, `{article_list}`, `{items}`, `{date}`, `{content}`.
 
@@ -118,8 +118,8 @@ Scrape sources with custom parsing need matching `if self.name == "..."` dispatc
 
 ## Environment Variables
 
-Required: `OPENROUTER_API_KEY`, `DISCORD_BOT_TOKEN`
-Optional: `DISCORD_CHANNEL_PAPERS/AI_NEWS/CODE/RESOURCE`, `FRESHRSS_USER/PASSWORD`, `DAILYINFO_DATA_ROOT` (default: `~/.myagentdata/dailyinfo`), `DAILYINFO_FALLBACK_MODEL`
+Required: `DEEPSEEK_API_KEY`, `DISCORD_BOT_TOKEN`
+Optional: `OPENROUTER_API_KEY` (fallback model), `DISCORD_CHANNEL_PAPERS/AI_NEWS/CODE/RESOURCE`, `FRESHRSS_USER/PASSWORD`, `DAILYINFO_DATA_ROOT` (default: `~/.myagentdata/dailyinfo`), `DAILYINFO_FALLBACK_MODEL`
 
 ## Testing Conventions
 
@@ -129,6 +129,20 @@ Optional: `DISCORD_CHANNEL_PAPERS/AI_NEWS/CODE/RESOURCE`, `FRESHRSS_USER/PASSWOR
 - `fake_call_ai` fixture stubs `run_pipelines.call_ai` with deterministic response, disables `time.sleep`
 - `rss_db` fixture provides in-memory SQLite with fresh/stale entry fixtures
 - Test files mirror source: `test_{module}.py` for `scripts/{module}.py`; `test_fetcher_*.py` for `dailyinfo_fetcher/`
+
+## Agent skills
+
+### Issue tracker
+
+Issues are tracked as GitHub issues on `iHeadWater/dailyinfo`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default label vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context — one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.
 
 ## Language
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ cd dailyinfo
 
 # 2. 创建配置文件
 cp .env.example .env
-# 编辑 .env，填入 OPENROUTER_API_KEY 和 DISCORD_BOT_TOKEN
+# 编辑 .env，填入 DEEPSEEK_API_KEY 和 DISCORD_BOT_TOKEN（OPENROUTER_API_KEY 可选，用于回退模型）
 
 # 3. 环境初始化（创建 ~/.myagentdata/dailyinfo 目录，安装依赖）
 uv sync --python python3
@@ -98,7 +98,7 @@ dailyinfo push
 | `dailyinfo status` | 查看今日 briefings / pushed 文件数量 |
 
 > `dailyinfo install` 不再写系统 crontab；调度请交给 myopenclaw 的 hermes cron 或外部调度器。
-> `run` 的 AI 调用会在主模型（`moonshotai/kimi-k2.5`）连续返回空响应时自动切到 `DAILYINFO_FALLBACK_MODEL`（默认 `deepseek/deepseek-chat-v3.1`）。
+> `run` 的 AI 调用会在主模型 DeepSeek V4 Pro 连续返回空响应时自动回退到 OpenRouter 的 `DAILYINFO_FALLBACK_MODEL`（默认 `moonshotai/kimi-k2.5`）。
 
 ## 配置
 
@@ -108,13 +108,14 @@ dailyinfo push
 
 | 变量 | 说明 |
 |------|------|
-| `OPENROUTER_API_KEY` | OpenRouter LLM API key（必填） |
+| `DEEPSEEK_API_KEY` | DeepSeek 官方 API key（必填） |
+| `OPENROUTER_API_KEY` | OpenRouter API key（可选，仅回退模型使用） |
 | `DISCORD_BOT_TOKEN` | Discord Bot Token（`dailyinfo push` 需要） |
 | `DISCORD_CHANNEL_PAPERS` / `_AI_NEWS` / `_CODE` / `_RESOURCE` / `_ARXIV` | 各分类频道 ID，缺失则跳过；arxiv 未配则复用 `DISCORD_CHANNEL_AI_NEWS` |
 | `FRESHRSS_USER` | FreshRSS 用户名，默认 `$USER` |
 | `FRESHRSS_PASSWORD` | FreshRSS 初始密码 |
 | `DAILYINFO_DATA_ROOT` | 覆盖默认数据根（默认 `~/.myagentdata/dailyinfo`） |
-| `DAILYINFO_FALLBACK_MODEL` | AI 备用模型（主模型空响应后切换，默认 `deepseek/deepseek-chat-v3.1`） |
+| `DAILYINFO_FALLBACK_MODEL` | AI 备用模型（主模型空响应后切换，默认 `moonshotai/kimi-k2.5`） |
 
 ## 从旧版本迁移
 
@@ -161,7 +162,7 @@ python3 scripts/discord_bot.py
 ## 技术栈
 
 - **RSS 聚合**: FreshRSS (Docker)
-- **AI 处理**: OpenRouter (moonshotai/kimi-k2.5)
+- **AI 处理**: DeepSeek V4 Pro 官方 API（回退：OpenRouter Kimi K2.5）
 - **推送**: Discord Bot API（Python `requests`）
 
 ## License

--- a/config/sources.json
+++ b/config/sources.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "defaults": {
-    "model": "moonshotai/kimi-k2.5",
+    "model": "deepseek-v4-pro",
     "lookback_hours": 24,
     "max_articles_per_batch": 10,
     "freshrss_user": ""

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/scripts/backfill_push.py
+++ b/scripts/backfill_push.py
@@ -51,11 +51,11 @@ def load_env(key):
     return os.environ.get(key, "")
 
 
-def call_ai(prompt, api_key, model="anthropic/claude-haiku-4-5", max_tokens=1500):
+def call_ai(prompt, api_key, model="deepseek-v4-pro", max_tokens=1500):
     import requests
 
     resp = requests.post(
-        "https://openrouter.ai/api/v1/chat/completions",
+        "https://api.deepseek.com/v1/chat/completions",
         headers={
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
@@ -136,9 +136,9 @@ def main():
     )
     args = parser.parse_args()
 
-    api_key = load_env("OPENROUTER_API_KEY")
+    api_key = load_env("DEEPSEEK_API_KEY")
     if not api_key or api_key.startswith("your_"):
-        log("ERROR: OPENROUTER_API_KEY not set in .env")
+        log("ERROR: DEEPSEEK_API_KEY not set in .env")
         sys.exit(1)
 
     discord_token = load_env("DISCORD_BOT_TOKEN")

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -97,7 +97,7 @@ def install():
         click.echo("  Run: cp .env.example .env and fill in your keys")
         sys.exit(1)
 
-    required = ["OPENROUTER_API_KEY", "DISCORD_BOT_TOKEN"]
+    required = ["DEEPSEEK_API_KEY", "DISCORD_BOT_TOKEN"]
     channel_keys = [
         "DISCORD_CHANNEL_PAPERS",
         "DISCORD_CHANNEL_AI_NEWS",

--- a/scripts/discord_bot.py
+++ b/scripts/discord_bot.py
@@ -18,8 +18,8 @@ from paths import BRIEFINGS_DIR, PUSHED_DIR
 # ---------------------------------------------------------------------------
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DISCORD_API = "https://discord.com/api/v10"
-OPENROUTER_API = "https://openrouter.ai/api/v1/chat/completions"
-ANALYSIS_MODEL = "anthropic/claude-sonnet-4-5"
+DEEPSEEK_API = "https://api.deepseek.com/v1/chat/completions"
+ANALYSIS_MODEL = "deepseek-v4-pro"
 LOOKBACK_DAYS = 3  # search briefings from this many days back
 
 
@@ -43,7 +43,7 @@ def _load_env() -> dict:
                         k, v = line.split("=", 1)
                         env[k.strip()] = v.strip().strip('"').strip("'")
     # environment variables override .env
-    for k in ("DISCORD_BOT_TOKEN", "OPENROUTER_API_KEY"):
+    for k in ("DISCORD_BOT_TOKEN", "DEEPSEEK_API_KEY"):
         if os.environ.get(k):
             env[k] = os.environ[k]
     return env
@@ -51,13 +51,13 @@ def _load_env() -> dict:
 
 ENV = _load_env()
 DISCORD_BOT_TOKEN = ENV.get("DISCORD_BOT_TOKEN", "")
-OPENROUTER_API_KEY = ENV.get("OPENROUTER_API_KEY", "")
+DEEPSEEK_API_KEY = ENV.get("DEEPSEEK_API_KEY", "")
 
 if not DISCORD_BOT_TOKEN:
     log("ERROR: DISCORD_BOT_TOKEN not set")
     sys.exit(1)
-if not OPENROUTER_API_KEY:
-    log("ERROR: OPENROUTER_API_KEY not set")
+if not DEEPSEEK_API_KEY:
+    log("ERROR: DEEPSEEK_API_KEY not set")
     sys.exit(1)
 
 HEADERS_DISCORD = {
@@ -149,8 +149,8 @@ def call_ai(user_query: str, context: str) -> str:
         "max_tokens": 2000,
     }
     resp = requests.post(
-        OPENROUTER_API,
-        headers={"Authorization": f"Bearer {OPENROUTER_API_KEY}", "Content-Type": "application/json"},
+        DEEPSEEK_API,
+        headers={"Authorization": f"Bearer {DEEPSEEK_API_KEY}", "Content-Type": "application/json"},
         json=payload,
         timeout=120,
     )

--- a/scripts/run_pipelines.py
+++ b/scripts/run_pipelines.py
@@ -2,7 +2,7 @@
 """DailyInfo Pipeline Runner — generates daily briefing files.
 
 Reads RSS feeds from FreshRSS, scrapes GitHub/HuggingFace trending,
-scrapes DUT university news, then calls OpenRouter AI for summaries.
+scrapes DUT university news, then calls DeepSeek AI for summaries (OpenRouter fallback).
 Output files are saved to ~/.myagentdata/dailyinfo/briefings/{category}/.
 
 Usage:
@@ -117,7 +117,32 @@ def load_api_key() -> str:
     sys.exit(1)
 
 
-DEFAULT_FALLBACK_MODEL = "deepseek/deepseek-chat-v3.1"
+def load_deepseek_key() -> str:
+    env_path = os.path.join(PROJECT_ROOT, ".env")
+    if os.path.exists(env_path):
+        try:
+            from dotenv import dotenv_values
+
+            key = dotenv_values(env_path).get("DEEPSEEK_API_KEY", "")
+            if key and not key.startswith("your_"):
+                return key
+        except ImportError:
+            with open(env_path) as f:
+                for line in f:
+                    line = line.strip()
+                    if line.startswith("DEEPSEEK_API_KEY=") and "your_" not in line:
+                        return line.split("=", 1)[1].strip()
+    key = os.environ.get("DEEPSEEK_API_KEY", "")
+    if key:
+        return key
+    log("ERROR: No DEEPSEEK_API_KEY found in .env or environment")
+    sys.exit(1)
+
+
+DEEPSEEK_API_URL = "https://api.deepseek.com/v1/chat/completions"
+OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions"
+
+DEFAULT_FALLBACK_MODEL = "moonshotai/kimi-k2.5"
 
 _BACKOFF_SECONDS = (2, 5, 10)
 
@@ -133,12 +158,12 @@ def _resolve_fallback_model(explicit: str | None) -> str:
     )
 
 
-def _post_openrouter(model: str, prompt: str, max_tokens: int):
-    """Issue a single OpenRouter chat completion call and return the parsed JSON."""
+def _post_ai(url: str, api_key: str, model: str, prompt: str, max_tokens: int):
+    """Issue a single AI chat completion call and return the parsed JSON."""
     resp = requests.post(
-        "https://openrouter.ai/api/v1/chat/completions",
+        url,
         headers={
-            "Authorization": f"Bearer {API_KEY}",
+            "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
         },
         json={
@@ -152,52 +177,84 @@ def _post_openrouter(model: str, prompt: str, max_tokens: int):
     return resp.json()
 
 
+def _get_deepseek_key() -> str:
+    """Load and cache the DeepSeek API key (exits if missing)."""
+    global _DEEPSEEK_KEY_CACHE
+    if _DEEPSEEK_KEY_CACHE is None:
+        _DEEPSEEK_KEY_CACHE = load_deepseek_key()
+    return _DEEPSEEK_KEY_CACHE
+
+
+_DEEPSEEK_KEY_CACHE: str | None = None
+
+
 def call_ai(
     prompt: str,
-    model: str = "moonshotai/kimi-k2.5",
+    model: str = "deepseek-v4-pro",
     max_tokens: int = 1200,
     *,
     fallback_model: str | None = None,
 ) -> str:
-    """Call OpenRouter with retries and a fallback model.
+    """Call DeepSeek API with retries, falling back to OpenRouter.
 
-    Strategy: 3 attempts on the primary model with exponential backoff
-    (2s / 5s / 10s), then up to 2 attempts on ``fallback_model``.
-    Empty or refusal responses are logged with the provider-reported
-    ``finish_reason`` to help diagnose truncation vs. content filtering.
+    Strategy: 3 attempts on the primary model via DeepSeek API with
+    exponential backoff (2s / 5s / 10s), then up to 2 attempts on
+    ``fallback_model`` via OpenRouter.
     """
     fallback = _resolve_fallback_model(fallback_model)
-    attempts_per_model = ((model, 3), (fallback, 2))
+    ds_key = _get_deepseek_key()
 
-    for mdl, attempts in attempts_per_model:
-        for i in range(attempts):
-            try:
-                data = _post_openrouter(mdl, prompt, max_tokens)
-            except requests.RequestException as exc:
-                log(f"  [call_ai] {mdl} attempt {i + 1}/{attempts} http_error={exc}")
-                time.sleep(_BACKOFF_SECONDS[min(i, len(_BACKOFF_SECONDS) - 1)])
-                continue
-
-            choice = (data.get("choices") or [{}])[0]
-            message = choice.get("message") or {}
-            finish_reason = choice.get("finish_reason") or "unknown"
-            content = (message.get("content") or "").strip()
-            if content and finish_reason != "length":
-                return content
-
-            reason = (
-                finish_reason or (data.get("error") or {}).get("message") or "empty"
-            )
-            log(
-                f"  [call_ai] {mdl} attempt {i + 1}/{attempts} incomplete "
-                f"(finish_reason={reason}, chars={len(content)})"
-            )
+    # ── Primary: DeepSeek API ──────────────────────────────────────
+    for i in range(3):
+        try:
+            data = _post_ai(DEEPSEEK_API_URL, ds_key, model, prompt, max_tokens)
+        except requests.RequestException as exc:
+            log(f"  [call_ai] {model} attempt {i + 1}/3 http_error={exc}")
             time.sleep(_BACKOFF_SECONDS[min(i, len(_BACKOFF_SECONDS) - 1)])
+            continue
 
-        if mdl != fallback:
-            log(
-                f"  [call_ai] primary {model} exhausted, switching to fallback {fallback}"
-            )
+        choice = (data.get("choices") or [{}])[0]
+        message = choice.get("message") or {}
+        finish_reason = choice.get("finish_reason") or "unknown"
+        content = (message.get("content") or "").strip()
+        if content and finish_reason != "length":
+            return content
+
+        reason = (
+            finish_reason or (data.get("error") or {}).get("message") or "empty"
+        )
+        log(
+            f"  [call_ai] {model} attempt {i + 1}/3 incomplete "
+            f"(finish_reason={reason}, chars={len(content)})"
+        )
+        time.sleep(_BACKOFF_SECONDS[min(i, len(_BACKOFF_SECONDS) - 1)])
+
+    log(f"  [call_ai] primary {model} exhausted, switching to fallback {fallback}")
+
+    # ── Fallback: OpenRouter ────────────────────────────────────────
+    for i in range(2):
+        try:
+            data = _post_ai(OPENROUTER_API_URL, API_KEY, fallback, prompt, max_tokens)
+        except requests.RequestException as exc:
+            log(f"  [call_ai] {fallback} attempt {i + 1}/2 http_error={exc}")
+            time.sleep(_BACKOFF_SECONDS[min(i, len(_BACKOFF_SECONDS) - 1)])
+            continue
+
+        choice = (data.get("choices") or [{}])[0]
+        message = choice.get("message") or {}
+        finish_reason = choice.get("finish_reason") or "unknown"
+        content = (message.get("content") or "").strip()
+        if content and finish_reason != "length":
+            return content
+
+        reason = (
+            finish_reason or (data.get("error") or {}).get("message") or "empty"
+        )
+        log(
+            f"  [call_ai] {fallback} attempt {i + 1}/2 incomplete "
+            f"(finish_reason={reason}, chars={len(content)})"
+        )
+        time.sleep(_BACKOFF_SECONDS[min(i, len(_BACKOFF_SECONDS) - 1)])
 
     raise BriefingGenerationError(
         f"call_ai: empty response after retries (model={model}, fallback={fallback})"
@@ -655,7 +712,7 @@ def _run_category_pipeline(category: str, *,
     path is used instead of the regular batched path.
     """
     cfg, defaults, templates = _load_sources()
-    model_default = defaults.get("model", "moonshotai/kimi-k2.5")
+    model_default = defaults.get("model", "deepseek-v4-pro")
     default_tmpl_key = defaults.get("prompt_template", "one_line_summary")
 
     # --- RSS sources ---
@@ -748,7 +805,7 @@ def run_pipeline_arxiv() -> int:
 def run_pipeline_code() -> int:
     log("=== Pipeline 4: Code Trending ===")
     cfg, defaults, templates = _load_sources()
-    model_default = defaults.get("model", "moonshotai/kimi-k2.5")
+    model_default = defaults.get("model", "deepseek-v4-pro")
     code_tmpl = templates.get("code_trending", "")
     saved = 0
 
@@ -896,7 +953,7 @@ def _generate_unified_news(
 def run_pipeline_resource() -> int:
     log("=== Pipeline 5: University News & Recruitment ===")
     cfg, defaults, prompt_templates = _load_sources()
-    model_default = defaults.get("model", "moonshotai/kimi-k2.5")
+    model_default = defaults.get("model", "deepseek-v4-pro")
     saved = 0
 
     # --- Part A: unified news briefing (8 news sources -> 1 file) ---

--- a/scripts/weekly_summary.py
+++ b/scripts/weekly_summary.py
@@ -24,7 +24,7 @@ import run_pipelines
 from run_pipelines import log
 
 DEEPSEEK_API_URL = "https://api.deepseek.com/v1/chat/completions"
-DEEPSEEK_MODEL = "deepseek-chat"
+DEEPSEEK_MODEL = "deepseek-v4-pro"
 
 
 def _load_deepseek_key() -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,7 +36,7 @@ def cli_mod(monkeypatch):
 
 def _write_valid_env(path):
     path.write_text(
-        "OPENROUTER_API_KEY=sk-real-test\n"
+        "DEEPSEEK_API_KEY=sk-real-test\n"
         "DISCORD_BOT_TOKEN=test-bot-token\n"
         "DISCORD_CHANNEL_PAPERS=1\n"
         "DISCORD_CHANNEL_AI_NEWS=2\n"
@@ -58,14 +58,14 @@ def test_install_fails_when_env_missing(cli_mod, tmp_path, monkeypatch):
 def test_install_fails_on_placeholder_key(cli_mod, tmp_path, monkeypatch):
     env = tmp_path / ".env"
     env.write_text(
-        "OPENROUTER_API_KEY=your_api_key_here\nDISCORD_BOT_TOKEN=real\n",
+        "DEEPSEEK_API_KEY=your_api_key_here\nDISCORD_BOT_TOKEN=real\n",
         encoding="utf-8",
     )
     monkeypatch.setattr(cli_mod, "ENV_FILE", env)
 
     result = CliRunner().invoke(cli_mod.cli, ["install"])
     assert result.exit_code == 1
-    assert "OPENROUTER_API_KEY" in result.output
+    assert "DEEPSEEK_API_KEY" in result.output
 
 
 def test_install_succeeds_with_full_env(cli_mod, tmp_path, monkeypatch):
@@ -82,7 +82,7 @@ def test_install_succeeds_with_full_env(cli_mod, tmp_path, monkeypatch):
 def test_install_warns_about_unset_channels(cli_mod, tmp_path, monkeypatch):
     env = tmp_path / ".env"
     env.write_text(
-        "OPENROUTER_API_KEY=sk-real-test\nDISCORD_BOT_TOKEN=tok\n",
+        "DEEPSEEK_API_KEY=sk-real-test\nDISCORD_BOT_TOKEN=tok\n",
         encoding="utf-8",
     )
     monkeypatch.setattr(cli_mod, "ENV_FILE", env)

--- a/tests/test_run_pipelines.py
+++ b/tests/test_run_pipelines.py
@@ -303,6 +303,7 @@ def _install_call_ai_stubs(monkeypatch, responses, logs):
     import run_pipelines as rp
 
     monkeypatch.setattr(rp, "API_KEY", "sk-test")
+    monkeypatch.setattr(rp, "_get_deepseek_key", lambda: "sk-test-ds")
     monkeypatch.setattr(rp.time, "sleep", lambda *_: None)
     monkeypatch.setattr(rp, "log", lambda msg: logs.append(msg))
 
@@ -1042,3 +1043,82 @@ def test_filter_sources_by_category_and_type():
     # Filter empty category
     result = rp._filter_sources(cfg, "code", "rss")
     assert result == []
+
+
+# ---------------------------------------------------------------------------
+# DeepSeek API key loading
+# ---------------------------------------------------------------------------
+
+
+def test_load_deepseek_key_from_env_var_when_no_dotenv(tmp_path, monkeypatch):
+    import run_pipelines as rp
+
+    monkeypatch.setattr(rp, "PROJECT_ROOT", str(tmp_path))  # empty dir → no .env
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-deepseek-test")
+
+    assert rp.load_deepseek_key() == "sk-deepseek-test"
+
+
+def test_load_deepseek_key_exits_when_missing(tmp_path, monkeypatch):
+    import run_pipelines as rp
+
+    monkeypatch.setattr(rp, "PROJECT_ROOT", str(tmp_path))
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+
+    with pytest.raises(SystemExit):
+        rp.load_deepseek_key()
+
+
+def test_load_deepseek_key_prefers_dotenv_over_env(tmp_path, monkeypatch):
+    import run_pipelines as rp
+
+    _write_env(tmp_path, "DEEPSEEK_API_KEY=sk-from-dotenv\n")
+    monkeypatch.setattr(rp, "PROJECT_ROOT", str(tmp_path))
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-from-env")
+
+    assert rp.load_deepseek_key() == "sk-from-dotenv"
+
+
+def test_load_deepseek_key_skips_placeholder_values(tmp_path, monkeypatch):
+    import run_pipelines as rp
+
+    _write_env(tmp_path, "DEEPSEEK_API_KEY=your_api_key_here\n")
+    monkeypatch.setattr(rp, "PROJECT_ROOT", str(tmp_path))
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-real")
+
+    assert rp.load_deepseek_key() == "sk-real"
+
+
+# ---------------------------------------------------------------------------
+# Dual-provider call_ai — DeepSeek primary, OpenRouter fallback
+# ---------------------------------------------------------------------------
+
+
+def test_call_ai_uses_deepseek_primary_openrouter_fallback(monkeypatch):
+    """Primary calls api.deepseek.com (3 tries), fallback calls openrouter.ai."""
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-ds")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or")
+
+    import run_pipelines as rp
+
+    logs: list[str] = []
+    call_urls: list[str] = []
+
+    def fake_post(url, *args, **kwargs):
+        call_urls.append(url)
+        if "deepseek" in url:
+            raise rp.requests.RequestException("deepseek transient error")
+        return _StubAIResponse(content="kimi fallback reply", finish_reason="stop")
+
+    monkeypatch.setattr(rp.time, "sleep", lambda *_: None)
+    monkeypatch.setattr(rp, "log", lambda msg: logs.append(msg))
+    monkeypatch.setattr(rp.requests, "post", fake_post)
+
+    result = rp.call_ai("summarise")
+
+    assert result == "kimi fallback reply"
+    deepseek_calls = [u for u in call_urls if "deepseek" in u]
+    openrouter_calls = [u for u in call_urls if "openrouter" in u]
+    assert len(deepseek_calls) == 3, f"expected 3 deepseek attempts, got {call_urls}"
+    assert len(openrouter_calls) == 1, f"expected 1 openrouter attempt, got {call_urls}"
+    assert "switching to fallback" in "\n".join(logs)


### PR DESCRIPTION
## Summary

Switch the primary AI model from OpenRouter `moonshotai/kimi-k2.5` to DeepSeek V4 Pro official API (`deepseek-v4-pro`). OpenRouter Kimi K2.5 is retained as the fallback model via dual-provider architecture.

Closes #45.

## Changes

### Core — Dual-provider architecture (`scripts/run_pipelines.py`)
- New `_post_ai()` generic function replaces `_post_openrouter()` — accepts URL and API key parameters
- `call_ai()` rewritten: primary 3 retries via DeepSeek API, then 2 fallback retries via OpenRouter
- New `load_deepseek_key()` and lazy `_get_deepseek_key()` for DeepSeek API key
- Default model: `deepseek-v4-pro`, fallback: `moonshotai/kimi-k2.5`
- Module-level `API_KEY` still loaded in `main()` for fallback

### Other scripts
- `scripts/discord_bot.py` — endpoint + model switched to DeepSeek
- `scripts/backfill_push.py` — endpoint + model + env var switched to DeepSeek
- `scripts/weekly_summary.py` — model changed from `deepseek-chat` to `deepseek-v4-pro`
- `scripts/cli.py` — `DEEPSEEK_API_KEY` now required, `OPENROUTER_API_KEY` optional

### Config
- `config/sources.json` — `defaults.model` → `deepseek-v4-pro`
- `.env.example` — updated template with `DEEPSEEK_API_KEY` as primary

### Docs
- `CLAUDE.md`, `AGENTS.md`, `README.md` — updated model references and env var docs
- `docs/agents/` — new agent skills config files (issue tracker, triage labels, domain docs)

## Files Changed

| File | Change |
|------|--------|
| `scripts/run_pipelines.py` | Modified — core dual-provider logic |
| `scripts/discord_bot.py` | Modified — DeepSeek endpoint |
| `scripts/backfill_push.py` | Modified — DeepSeek endpoint |
| `scripts/weekly_summary.py` | Modified — model name |
| `scripts/cli.py` | Modified — required env vars |
| `config/sources.json` | Modified — default model |
| `.env.example` | Modified — template update |
| `CLAUDE.md` | Modified — docs |
| `AGENTS.md` | Modified — docs |
| `README.md` | Modified — docs |
| `tests/test_run_pipelines.py` | Modified — 5 new tests + fixes |
| `tests/test_cli.py` | Modified — env var names |
| `docs/agents/` | Added — 3 new files |

## Test plan

- [x] All 160 tests pass locally
- [x] `dailyinfo install` validates `.env` with `DEEPSEEK_API_KEY`
- [ ] Run `dailyinfo run -p 1` with a single source to verify end-to-end DeepSeek API call
- [ ] Verify fallback triggers correctly when DeepSeek API is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)