### PR TITLE
fix: HuggingFace fetch 失败改为重试+占位，对齐 Pipeline 1 容错机制

### DIFF
--- a/scripts/run_pipelines.py
+++ b/scripts/run_pipelines.py
@@ -822,10 +822,19 @@ def run_pipeline_code() -> int:
             )
             continue
 
-        try:
-            items = ds.fetch()
-        except Exception as e:
-            log(f"    FETCH ERR: {e}")
+        items = None
+        for _attempt in range(3):
+            try:
+                items = ds.fetch()
+                break
+            except Exception as e:
+                log(f"    FETCH ERR (attempt {_attempt + 1}/3): {e}")
+                if _attempt < 2:
+                    time.sleep(_BACKOFF_SECONDS[_attempt])
+        if items is None:
+            placeholder = f"# {ds.display_name} - {DATE}\n\n⚠️ 获取失败\n"
+            save("code", f"{ds.name}_briefing_{DATE}.md", placeholder)
+            saved += 1
             continue
 
         if not items:
@@ -868,6 +877,9 @@ def run_pipeline_code() -> int:
             time.sleep(1)
         except Exception as e:
             log(f"    AI ERR: {e}")
+            placeholder = f"# {ds.display_name} - {DATE}\n\n⚠️ AI 生成失败\n"
+            save("code", f"{ds.name}_briefing_{DATE}.md", placeholder)
+            saved += 1
 
     log(f"  Pipeline 4 done: {saved} files saved")
     return saved

--- a/tests/test_run_pipelines.py
+++ b/tests/test_run_pipelines.py
@@ -984,7 +984,7 @@ def test_pipeline_code_skips_when_briefing_already_exists(
 def test_pipeline_code_skips_when_fetch_fails(
     monkeypatch, fake_requests, fake_call_ai
 ):
-    """When the scraper raises, pipeline logs and continues without saving."""
+    """When the scraper raises after retries, pipeline writes a placeholder file."""
     import requests
 
     import run_pipelines as rp
@@ -998,11 +998,11 @@ def test_pipeline_code_skips_when_fetch_fails(
     monkeypatch.setattr(requests, "get", boom)
 
     saved = rp.run_pipeline_code()
-    assert saved == 0
+    assert saved == 1
     today = datetime.now().strftime("%Y-%m-%d")
-    assert not (
-        BRIEFINGS_DIR / "code" / f"github_trending_briefing_{today}.md"
-    ).exists()
+    placeholder = BRIEFINGS_DIR / "code" / f"github_trending_briefing_{today}.md"
+    assert placeholder.exists()
+    assert "⚠️ 获取失败" in placeholder.read_text()
 
 
 # -----------------------------------------------------------------


### PR DESCRIPTION
closes #34

## 问题

Pipeline 4 中 HuggingFace 三个源 fetch 失败时直接跳过，不写任何文件，用户侧完全无感知。

## 改动

- fetch 失败改为最多重试 3 次（间隔 2s/5s），全部失败后写占位文件 `⚠️ 获取失败`
- AI 生成失败补写占位文件 `⚠️ AI 生成失败`
- 更新对应测试

## 验证方式

通过 mock 模拟 fetch 失败场景验证，未在真实环境中复现，无法确认真实场景下的表现。

## 注意

Issue 描述的是 Pipeline 2，实际代码已重构，HuggingFace 现在在 Pipeline 4（`run_pipeline_code()`）。