### PR TITLE
fix: add FreshRSS cache recovery for stuck arXiv feed

### DIFF
--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -14,6 +14,7 @@ Usage:
 """
 
 import os
+import json
 import subprocess
 import sys
 from datetime import datetime
@@ -460,6 +461,90 @@ def logs():
         sys.exit(1)
     result = subprocess.run(["tail", "-n", "100", str(log_file)])
     sys.exit(result.returncode)
+
+
+def _source_url(source_name: str) -> str:
+    """Resolve a configured source URL from config/sources.json."""
+    sources_path = PROJECT_ROOT / "config" / "sources.json"
+    with open(sources_path, encoding="utf-8") as f:
+        cfg = json.load(f)
+    for source in cfg.get("sources", []):
+        if source.get("name") == source_name:
+            return source.get("url", "")
+    return ""
+
+
+@cli.command("cache-clear")
+@click.option(
+    "--source",
+    default="arxiv_cs_ai",
+    show_default=True,
+    help="Configured source name whose FreshRSS cache should be cleared.",
+)
+@click.option("--url", default="", help="Explicit feed URL to clear instead of --source.")
+@click.option("--all-stale", is_flag=True, help="Clear every stale SimplePie cache entry.")
+@click.option("--max-age", default=24, show_default=True, help="Stale threshold in hours for --all-stale.")
+@click.option("--dry-run", is_flag=True, help="Show what would be deleted without deleting.")
+@click.option("--refresh", is_flag=True, help="Run FreshRSS actualize_script.php after clearing.")
+@click.option("--container", default="dailyinfo_freshrss", show_default=True, help="FreshRSS container name for --refresh.")
+def cache_clear(source, url, all_stale, max_age, dry_run, refresh, container):
+    """Clear FreshRSS SimplePie cache files for stuck feeds (see issue #57)."""
+    sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
+    from freshrss_cache import (
+        clear_stale_caches,
+        delete_cache_files,
+        find_cache_files_for_url,
+        find_stale_caches,
+        refresh_freshrss,
+    )
+    from paths import FRESHRSS_DATA
+
+    cache_dir = FRESHRSS_DATA / "cache"
+    if not cache_dir.exists():
+        click.echo(f"Cache directory not found: {cache_dir}")
+        sys.exit(1)
+
+    if all_stale:
+        targets = find_stale_caches(cache_dir, max_age_hours=max_age)
+        description = f"stale cache file(s) older than {max_age}h"
+    else:
+        feed_url = url or _source_url(source)
+        if not feed_url:
+            click.echo(f"Source not found or has no URL: {source}")
+            sys.exit(1)
+        targets = find_cache_files_for_url(cache_dir, feed_url)
+        description = f"cache file(s) for {source if not url else feed_url}"
+
+    if not targets:
+        click.echo(f"No {description} found.")
+        return
+
+    click.echo(f"Found {len(targets)} {description}:")
+    for f in targets:
+        click.echo(f"  {f.name}")
+
+    if dry_run:
+        click.echo("Dry run — nothing deleted.")
+        return
+
+    count = (
+        clear_stale_caches(cache_dir, max_age_hours=max_age)
+        if all_stale
+        else delete_cache_files(targets)
+    )
+    click.echo(f"Deleted {count} cache file(s).")
+
+    if refresh:
+        result = refresh_freshrss(container=container)
+        if result.returncode != 0:
+            click.echo("FreshRSS refresh failed.")
+            sys.exit(result.returncode)
+        click.echo("FreshRSS refresh triggered.")
+    else:
+        click.echo(
+            "Run with --refresh or execute: "
+            f"docker exec {container} php /var/www/FreshRSS/app/actualize_script.php"
+        )
 
 
 @cli.command("weekly-report")

--- a/scripts/freshrss_cache.py
+++ b/scripts/freshrss_cache.py
@@ -1,0 +1,154 @@
+"""FreshRSS SimplePie cache utilities.
+
+Provides helpers to detect and clear stale cache files that can cause feeds
+to stop updating silently (see issue #57).
+"""
+
+import datetime
+import json
+import subprocess
+import time
+from pathlib import Path
+from typing import Iterable, List
+from urllib.parse import urlparse
+
+
+def _cache_files(cache_dir: Path) -> Iterable[Path]:
+    """Yield FreshRSS SimplePie cache files recursively."""
+    if not cache_dir.exists():
+        return []
+    return cache_dir.rglob("*")
+
+
+def _candidate_tokens(url: str) -> list[str]:
+    """Return stable URL fragments likely to appear in SimplePie cache files."""
+    parsed = urlparse(url)
+    tokens = [url]
+    if parsed.netloc:
+        tokens.append(parsed.netloc)
+    if parsed.netloc and parsed.path:
+        tokens.append(f"{parsed.netloc}{parsed.path}")
+    return [token for token in tokens if token]
+
+
+def _file_contains_any(path: Path, tokens: list[str]) -> bool:
+    """Read a small cache file as bytes and search URL tokens defensively."""
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return False
+    return any(token.encode("utf-8") in data for token in tokens)
+
+
+def find_stale_caches(cache_dir: Path, max_age_hours: int = 24) -> List[Path]:
+    """Return stale .spc cache files not modified within max_age_hours."""
+    if not cache_dir.exists():
+        return []
+    cutoff = time.time() - max_age_hours * 3600
+    return [
+        f
+        for f in cache_dir.rglob("*.spc")
+        if f.is_file() and f.stat().st_mtime < cutoff
+    ]
+
+
+def find_cache_files_for_url(cache_dir: Path, url: str) -> List[Path]:
+    """Return cache files whose contents identify the requested feed URL."""
+    tokens = _candidate_tokens(url)
+    matched: set[Path] = set()
+    for path in _cache_files(cache_dir):
+        if not path.is_file() or path.suffix not in {".spc", ".html"}:
+            continue
+        if _file_contains_any(path, tokens):
+            matched.add(path)
+            if path.suffix == ".spc":
+                matched.add(path.with_suffix(".html"))
+            elif path.suffix == ".html":
+                matched.add(path.with_suffix(".spc"))
+    return sorted(p for p in matched if p.exists())
+
+
+def delete_cache_files(files: Iterable[Path]) -> int:
+    """Delete cache files and return the number actually removed."""
+    count = 0
+    for path in sorted(set(files)):
+        try:
+            path.unlink(missing_ok=True)
+            count += 1
+        except OSError:
+            continue
+    return count
+
+
+def clear_stale_caches(cache_dir: Path, max_age_hours: int = 24) -> int:
+    """Delete stale .spc cache files and their paired .html files."""
+    targets: set[Path] = set()
+    for spc in find_stale_caches(cache_dir, max_age_hours):
+        targets.add(spc)
+        targets.add(spc.with_suffix(".html"))
+    return delete_cache_files(p for p in targets if p.exists())
+
+
+def zero_state_path(state_dir: Path, source_name: str) -> Path:
+    """Return the persistent zero-result state path for a source."""
+    return state_dir / f"{source_name}_zero_state.json"
+
+
+def record_zero_result(
+    state_dir: Path, source_name: str, date: str | None = None
+) -> int:
+    """Record one zero-result day and return the consecutive zero-day count."""
+    today = date or datetime.date.today().isoformat()
+    path = zero_state_path(state_dir, source_name)
+    previous = {}
+    if path.exists():
+        try:
+            previous = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            previous = {}
+
+    last_date = previous.get("last_zero_date", "")
+    count = int(previous.get("consecutive_zero_days", 0) or 0)
+    yesterday = (
+        datetime.date.fromisoformat(today) - datetime.timedelta(days=1)
+    ).isoformat()
+
+    if last_date == today:
+        new_count = max(count, 1)
+    elif last_date == yesterday:
+        new_count = count + 1
+    else:
+        new_count = 1
+
+    state_dir.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {"last_zero_date": today, "consecutive_zero_days": new_count},
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return new_count
+
+
+def reset_zero_result(state_dir: Path, source_name: str) -> None:
+    """Clear zero-result state when a source successfully returns items."""
+    try:
+        zero_state_path(state_dir, source_name).unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def refresh_freshrss(container: str = "dailyinfo_freshrss") -> subprocess.CompletedProcess:
+    """Trigger FreshRSS feed refresh inside the container."""
+    return subprocess.run(
+        [
+            "docker",
+            "exec",
+            container,
+            "php",
+            "/var/www/FreshRSS/app/actualize_script.php",
+        ],
+        text=True,
+    )

--- a/scripts/run_pipelines.py
+++ b/scripts/run_pipelines.py
@@ -588,7 +588,19 @@ def _process_regular_source(ds, feed_cfg: dict, model_default: str,
         ds.cleanup_seen()
         placeholder = f"# {ds.display_name} - {DATE}\n\n" + "\U0001f4ed 过去 {ds.lookback_hours} 小时无新内容\n"
         save(category, f"{name}_briefing_{DATE}.md", placeholder)
+        if isinstance(ds, RSSDataSource):
+            from freshrss_cache import record_zero_result
+            zero_days = record_zero_result(STATE_DIR, name, DATE)
+            if zero_days >= 2:
+                log(
+                    f"  [WARN] {name}: {zero_days} consecutive days with 0 articles — "
+                    f"FreshRSS cache may be stuck. Run: dailyinfo cache-clear"
+                )
         return 1
+
+    if isinstance(ds, RSSDataSource):
+        from freshrss_cache import reset_zero_result
+        reset_zero_result(STATE_DIR, name)
 
     if ds.lookback_hours > 24 and _already_pushed_within(name, category, ds.lookback_hours):
         log(f"  {name}: {len(items)} articles - already pushed within {ds.lookback_hours}h, skip")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -403,3 +403,69 @@ class TestCleanCacheCommand:
         assert result.exit_code == 1, result.output
         assert "Cleaned 2 stale cache file(s)" in result.output
         assert "1 error(s)" in result.output
+
+
+def test_cache_clear_defaults_to_arxiv_source(cli_mod):
+    from paths import FRESHRSS_DATA
+
+    cache_dir = FRESHRSS_DATA / "cache"
+    cache_dir.mkdir(parents=True)
+    arxiv_spc = cache_dir / "arxiv.spc"
+    arxiv_html = cache_dir / "arxiv.html"
+    nature_spc = cache_dir / "nature.spc"
+    arxiv_spc.write_text("https://rss.arxiv.org/rss/cs.AI", encoding="utf-8")
+    arxiv_html.write_text("cached html", encoding="utf-8")
+    nature_spc.write_text("https://www.nature.com/nature.rss", encoding="utf-8")
+
+    result = CliRunner().invoke(cli_mod.cli, ["cache-clear"])
+
+    assert result.exit_code == 0, result.output
+    assert "Deleted 2 cache file(s)." in result.output
+    assert not arxiv_spc.exists()
+    assert not arxiv_html.exists()
+    assert nature_spc.exists()
+
+
+def test_cache_clear_dry_run_keeps_files(cli_mod):
+    from paths import FRESHRSS_DATA
+
+    cache_dir = FRESHRSS_DATA / "cache"
+    cache_dir.mkdir(parents=True)
+    arxiv_spc = cache_dir / "arxiv.spc"
+    arxiv_spc.write_text("https://rss.arxiv.org/rss/cs.AI", encoding="utf-8")
+
+    result = CliRunner().invoke(cli_mod.cli, ["cache-clear", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert "Dry run" in result.output
+    assert arxiv_spc.exists()
+
+
+def test_cache_clear_refresh_runs_actualize_script(cli_mod, monkeypatch):
+    from paths import FRESHRSS_DATA
+    import freshrss_cache
+
+    cache_dir = FRESHRSS_DATA / "cache"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "arxiv.spc").write_text("https://rss.arxiv.org/rss/cs.AI", encoding="utf-8")
+
+    calls = []
+
+    def fake_run(cmd, *args, **kwargs):
+        calls.append(cmd)
+        return _FakeCompleted(returncode=0)
+
+    monkeypatch.setattr(freshrss_cache.subprocess, "run", fake_run)
+
+    result = CliRunner().invoke(cli_mod.cli, ["cache-clear", "--refresh"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        [
+            "docker",
+            "exec",
+            "dailyinfo_freshrss",
+            "php",
+            "/var/www/FreshRSS/app/actualize_script.php",
+        ]
+    ]

--- a/tests/test_datasource_rss.py
+++ b/tests/test_datasource_rss.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import datetime
+
 DEFAULTS = {"lookback_hours": 24}
 
 
@@ -239,8 +241,6 @@ def test_commit_seen_empty_list_is_harmless(rss_db):
 
 def test_cleanup_seen_removes_old_entries(rss_db):
     """cleanup_seen should remove entries older than max_age_days."""
-    from datasource import Item
-
     ds = _make_rss(
         {
             "name": "test_feed1",
@@ -250,18 +250,19 @@ def test_cleanup_seen_removes_old_entries(rss_db):
         },
         rss_db,
     )
+    old_1 = (datetime.date.today() - datetime.timedelta(days=42)).isoformat()
+    old_2 = (datetime.date.today() - datetime.timedelta(days=33)).isoformat()
+    recent = (datetime.date.today() - datetime.timedelta(days=1)).isoformat()
+
     # Manually add old + new entries to seen
     ds._seen = {
-        "https://old.com/1": "2026-04-01",
-        "https://old.com/2": "2026-04-10",
-        "https://new.com/1": "2026-05-12",
+        "https://old.com/1": old_1,
+        "https://old.com/2": old_2,
+        "https://new.com/1": recent,
     }
     ds._save_seen()
 
     ds.cleanup_seen(max_age_days=30)
-    # 2026-04-01 is 42 days before 2026-05-13 → removed
-    # 2026-04-10 is 33 days before → removed
-    # 2026-05-12 is 1 day before → kept
     assert "https://old.com/1" not in ds._seen
     assert "https://old.com/2" not in ds._seen
     assert "https://new.com/1" in ds._seen

--- a/tests/test_freshrss_cache.py
+++ b/tests/test_freshrss_cache.py
@@ -1,0 +1,77 @@
+"""Tests for FreshRSS SimplePie cache utilities."""
+
+from __future__ import annotations
+
+import json
+
+
+def test_find_cache_files_for_url_matches_feed_and_pair(tmp_path):
+    from freshrss_cache import find_cache_files_for_url
+
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    spc = cache_dir / "abc.spc"
+    html = cache_dir / "abc.html"
+    other = cache_dir / "other.spc"
+
+    spc.write_text("https://rss.arxiv.org/rss/cs.AI", encoding="utf-8")
+    html.write_text("<rss>cached</rss>", encoding="utf-8")
+    other.write_text("https://www.nature.com/nature.rss", encoding="utf-8")
+
+    result = find_cache_files_for_url(cache_dir, "https://rss.arxiv.org/rss/cs.AI")
+
+    assert result == [html, spc]
+
+
+def test_find_cache_files_for_url_recurses_nested_cache_dirs(tmp_path):
+    from freshrss_cache import find_cache_files_for_url
+
+    nested = tmp_path / "cache" / "feeds"
+    nested.mkdir(parents=True)
+    spc = nested / "nested.spc"
+    spc.write_text("serialized rss.arxiv.org/rss/cs.AI cache", encoding="utf-8")
+
+    assert find_cache_files_for_url(tmp_path / "cache", "https://rss.arxiv.org/rss/cs.AI") == [spc]
+
+
+def test_delete_cache_files_returns_removed_count(tmp_path):
+    from freshrss_cache import delete_cache_files
+
+    first = tmp_path / "a.spc"
+    second = tmp_path / "a.html"
+    first.write_text("x", encoding="utf-8")
+    second.write_text("x", encoding="utf-8")
+
+    assert delete_cache_files([first, second]) == 2
+    assert not first.exists()
+    assert not second.exists()
+
+
+def test_record_zero_result_counts_consecutive_days(tmp_path):
+    from freshrss_cache import record_zero_result
+
+    assert record_zero_result(tmp_path, "arxiv_cs_ai", "2026-06-27") == 1
+    assert record_zero_result(tmp_path, "arxiv_cs_ai", "2026-06-28") == 2
+    assert record_zero_result(tmp_path, "arxiv_cs_ai", "2026-06-28") == 2
+
+    state = json.loads((tmp_path / "arxiv_cs_ai_zero_state.json").read_text())
+    assert state == {
+        "last_zero_date": "2026-06-28",
+        "consecutive_zero_days": 2,
+    }
+
+
+def test_record_zero_result_resets_after_gap(tmp_path):
+    from freshrss_cache import record_zero_result
+
+    assert record_zero_result(tmp_path, "arxiv_cs_ai", "2026-06-20") == 1
+    assert record_zero_result(tmp_path, "arxiv_cs_ai", "2026-06-25") == 1
+
+
+def test_reset_zero_result_removes_state(tmp_path):
+    from freshrss_cache import record_zero_result, reset_zero_result
+
+    record_zero_result(tmp_path, "arxiv_cs_ai", "2026-06-27")
+    reset_zero_result(tmp_path, "arxiv_cs_ai")
+
+    assert not (tmp_path / "arxiv_cs_ai_zero_state.json").exists()

--- a/tests/test_run_pipelines.py
+++ b/tests/test_run_pipelines.py
@@ -116,14 +116,13 @@ def test_load_api_key_from_env_var_when_no_dotenv(tmp_path, monkeypatch):
     assert rp.load_api_key() == "sk-test-env"
 
 
-def test_load_api_key_exits_when_missing(tmp_path, monkeypatch):
+def test_load_api_key_returns_empty_when_missing(tmp_path, monkeypatch):
     import run_pipelines as rp
 
     monkeypatch.setattr(rp, "PROJECT_ROOT", str(tmp_path))
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
 
-    with pytest.raises(SystemExit):
-        rp.load_api_key()
+    assert rp.load_api_key() == ""
 
 
 def test_load_api_key_prefers_dotenv_over_env(tmp_path, monkeypatch):
@@ -276,6 +275,90 @@ def test_resolve_fallback_model_default(monkeypatch):
 
     monkeypatch.delenv("DAILYINFO_FALLBACK_MODEL", raising=False)
     assert rp._resolve_fallback_model(None) == rp.DEFAULT_FALLBACK_MODEL
+
+
+def test_process_regular_source_records_zero_state_for_empty_rss(rss_db, monkeypatch):
+    import run_pipelines as rp
+    from datasource import RSSDataSource
+    from paths import STATE_DIR
+
+    ds = RSSDataSource(
+        {
+            "name": "arxiv_cs_ai",
+            "type": "rss",
+            "category": "arxiv",
+            "url": "https://rss.arxiv.org/rss/cs.AI",
+        },
+        {},
+        db=rss_db,
+    )
+    monkeypatch.setattr(ds, "fetch", lambda: [])
+
+    saved = rp._process_regular_source(
+        ds,
+        ds.config,
+        "deepseek-v4-pro",
+        {"one_line_summary": "summarize {article_list}"},
+        "one_line_summary",
+    )
+
+    assert saved == 1
+    assert (STATE_DIR / "arxiv_cs_ai_zero_state.json").exists()
+
+
+def test_process_regular_source_resets_zero_state_when_rss_recovers(
+    rss_db, monkeypatch
+):
+    import run_pipelines as rp
+    from datasource import Item, RSSDataSource
+    from freshrss_cache import record_zero_result
+    from paths import STATE_DIR
+
+    record_zero_result(STATE_DIR, "arxiv_cs_ai", rp.DATE)
+    ds = RSSDataSource(
+        {
+            "name": "arxiv_cs_ai",
+            "display_name": "arXiv CS.AI",
+            "type": "rss",
+            "category": "arxiv",
+            "url": "https://rss.arxiv.org/rss/cs.AI",
+        },
+        {},
+        db=rss_db,
+    )
+    monkeypatch.setattr(
+        ds,
+        "fetch",
+        lambda: [
+            Item(
+                title="Recovered Paper",
+                date=rp.DATE,
+                url="https://arxiv.org/abs/1",
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        rp,
+        "call_ai",
+        lambda *args, **kwargs: (
+            "## arXiv CS.AI 今日简报\n\n"
+            "1. **Recovered Paper**\n"
+            "   > 中文摘要。\n\n"
+            "🔭 **Today's Highlight**\n"
+            "恢复更新。"
+        ),
+    )
+
+    saved = rp._process_regular_source(
+        ds,
+        ds.config,
+        "deepseek-v4-pro",
+        {"one_line_summary": "summarize {article_list}"},
+        "one_line_summary",
+    )
+
+    assert saved == 1
+    assert not (STATE_DIR / "arxiv_cs_ai_zero_state.json").exists()
 
 
 class _StubAIResponse:


### PR DESCRIPTION
## Summary
- add targeted FreshRSS SimplePie cache clearing for configured feeds
- persist zero-result tracking outside briefing files so push cleanup does not hide repeated empty RSS runs
- add optional FreshRSS actualize refresh support
- add tests for cache utilities, CLI behavior, and zero-state handling

Fixes #57.

## Tests
- uv run pytest -q tests/test_freshrss_cache.py tests/test_cli.py tests/test_run_pipelines.py tests/test_datasource_rss.py

## Note
- Full suite currently has one environment/dependency failure on latest dev: tests/test_zotero_sync.py::test_get_zotero_client_returns_client requires pyzotero, which is not installed in this environment. The #57-related test subset passes.