### PR TITLE
fix: deduplicate non-RSS paper sources

### DIFF
--- a/scripts/datasource.py
+++ b/scripts/datasource.py
@@ -385,11 +385,11 @@ class RSSDataSource(DataSource):
 class ScrapeDataSource(DataSource):
     def fetch(self) -> list[Item]:
         if self.name == "github_trending":
-            return self._fetch_github()
+            return self._filter_seen(self._fetch_github())
         if self.name == "chinawater":
-            return self._fetch_chinawater_journal()
+            return self._filter_seen(self._fetch_chinawater_journal())
         if self.name == "skxjz":
-            return self._fetch_skxjz_journal()
+            return self._filter_seen(self._fetch_skxjz_journal())
         resp = requests.get(
             self.config["url"],
             timeout=20,
@@ -399,8 +399,8 @@ class ScrapeDataSource(DataSource):
         )
         resp.encoding = resp.apparent_encoding or "utf-8"
         if self.name == "skxjz":
-            return self._parse_skxjz(resp.text)
-        return self._parse_dlut_html(resp.text)
+            return self._filter_seen(self._parse_skxjz(resp.text))
+        return self._filter_seen(self._parse_dlut_html(resp.text))
 
     # --- GitHub Trending ---
     def _fetch_github(self) -> list[Item]:
@@ -744,7 +744,7 @@ class APIDataSource(DataSource):
         params = self.config.get("params", {})
         if method == "POST":
             if self.config.get("paginate"):
-                return self._fetch_dlut_paginated(params)
+                return self._filter_seen(self._fetch_dlut_paginated(params))
             resp = requests.post(self.config["url"], data=params, timeout=20)
         else:
             params_str = {k: str(v) for k, v in params.items()}
@@ -757,10 +757,10 @@ class APIDataSource(DataSource):
         data = resp.json()
 
         if self.name.startswith("huggingface_"):
-            return self._parse_huggingface(data)
+            return self._filter_seen(self._parse_huggingface(data))
         if self.config.get("parser") == "crossref":
-            return self._parse_crossref(data)
-        return self._parse_dlut_api(data)
+            return self._filter_seen(self._parse_crossref(data))
+        return self._filter_seen(self._parse_dlut_api(data))
 
     def _fetch_dlut_paginated(self, base_params: dict) -> list[Item]:
         """Paginate DLUT POST API.

--- a/tests/test_datasource_api.py
+++ b/tests/test_datasource_api.py
@@ -259,3 +259,46 @@ def test_dlut_api_list_key_shape():
         DEFAULTS,
     )
     assert [it.title for it in ds._parse_dlut_api(api_data)] == ["first"]
+
+
+def test_crossref_fetch_filters_seen_articles(fake_requests):
+    from conftest import FakeResponse
+    from datasource import DataSource
+
+    now = datetime.now()
+    payload = {
+        "message": {
+            "items": [
+                {
+                    "title": ["Hydraulic engineering paper"],
+                    "URL": "https://doi.org/10.1234/example",
+                    "DOI": "10.1234/example",
+                    "published": {
+                        "date-parts": [[now.year, now.month, now.day]]
+                    },
+                }
+            ]
+        }
+    }
+    fake_requests.register(
+        "https://api.crossref.org/works",
+        FakeResponse(status=200, json_data=payload),
+    )
+
+    cfg = {
+        "name": "shuili_xuebao",
+        "display_name": "水利学报",
+        "category": "papers",
+        "type": "api",
+        "url": "https://api.crossref.org/works",
+        "parser": "crossref",
+        "lookback_hours": 720,
+    }
+
+    first = DataSource.create(cfg, DEFAULTS)
+    first_items = first.fetch()
+    assert [item.title for item in first_items] == ["Hydraulic engineering paper"]
+    first.commit_seen(first_items)
+
+    second = DataSource.create(cfg, DEFAULTS)
+    assert second.fetch() == []

--- a/tests/test_datasource_scrape.py
+++ b/tests/test_datasource_scrape.py
@@ -157,3 +157,50 @@ def test_dlut_news_respects_max_items(fake_requests):
     )
 
     assert len(ds.fetch()) == 2
+
+
+def test_chinawater_filters_seen_articles(fake_requests):
+    from conftest import FakeResponse
+    from datasource import DataSource
+
+    today = datetime.now().strftime("%Y-%m-%d")
+    index_html = (
+        '<a href="guokan_list?year=2026&issue=13&yearId=year-uuid'
+        '&issueId=issue-uuid">2026年13期</a>'
+    )
+    list_html = """
+    <a href="/portal/journal/portal/client/paper/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">水利调度研究</a>
+    <a href="/portal/journal/portal/client/paper/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb">智慧水网建设</a>
+    """
+    detail_html = f"<div>出版时间：{today}</div>"
+
+    fake_requests.register(
+        "https://slzg.cbpt.cnki.net/portal/journal/portal/client/index",
+        FakeResponse(status=200, text=index_html),
+    )
+    fake_requests.register(
+        "https://slzg.cbpt.cnki.net/portal/journal/portal/client/guokan_list",
+        FakeResponse(status=200, text=list_html),
+    )
+    fake_requests.register(
+        "https://slzg.cbpt.cnki.net/portal/journal/portal/client/paper",
+        FakeResponse(status=200, text=detail_html),
+    )
+
+    cfg = {
+        "name": "chinawater",
+        "display_name": "中国水利",
+        "category": "papers",
+        "type": "scrape",
+        "url": "https://slzg.cbpt.cnki.net/portal/journal/portal/client/index",
+        "lookback_hours": 48,
+        "max_items": 20,
+    }
+
+    first = DataSource.create(cfg, DEFAULTS)
+    first_items = first.fetch()
+    assert [item.title for item in first_items] == ["水利调度研究", "智慧水网建设"]
+    first.commit_seen(first_items)
+
+    second = DataSource.create(cfg, DEFAULTS)
+    assert second.fetch() == []


### PR DESCRIPTION
## Summary
- apply seen-link filtering to scrape and API data sources
- prevent China Water (`chinawater`) current-issue articles from being regenerated after `commit_seen`
- add Crossref regression coverage for API paper sources such as `shuili_xuebao`

Fixes #50.

## Tests
- uv run pytest -q tests/test_datasource_scrape.py tests/test_datasource_api.py tests/test_datasource_rss.py tests/test_run_pipelines.py

## Note
- Full suite currently has one environment/dependency failure: tests/test_zotero_sync.py::test_get_zotero_client_returns_client requires pyzotero, which is not installed in this environment. The #50-related test subset passes.