### PR TITLE
fix: restore shuili xuebao Crossref updates

### DIFF
--- a/config/sources.json
+++ b/config/sources.json
@@ -294,7 +294,7 @@
       "display_name": "水利学报",
       "category": "papers",
       "enabled": true,
-      "url": "https://api.crossref.org/works?filter=issn:0559-9350&sort=published&order=desc&rows=20",
+      "url": "https://api.crossref.org/works?filter=issn:0559-9350&sort=updated&order=desc&rows=20",
       "type": "api",
       "parser": "crossref",
       "lookback_hours": 720,

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -38,7 +38,7 @@ This page is generated from [`config/sources.json`](https://github.com/iHeadWate
 | advances_water_resources | Advances in Water Resources | papers | rss | True | 24 | https://rss.sciencedirect.com/publication/science/03091708 |
 | journal_hydrology | Journal of Hydrology | papers | rss | True | 24 | https://rss.sciencedirect.com/publication/science/00221694 |
 | skxjz | 水科学进展 | papers | scrape | True | 48 | http://skxjz.nhri.cn/article/current |
-| shuili_xuebao | 水利学报 | papers | api | True | 720 | https://api.crossref.org/works?filter=issn:0559-9350&sort=published&order=desc&rows=20 |
+| shuili_xuebao | 水利学报 | papers | api | True | 720 | https://api.crossref.org/works?filter=issn:0559-9350&sort=updated&order=desc&rows=20 |
 | chinawater | 中国水利 | papers | scrape | True | 48 | https://slzg.cbpt.cnki.net/portal/journal/portal/client/index |
 | smolai_news | SmolAI News | ai_news | rss | True | 24 | https://news.smol.ai/rss.xml |
 | arxiv_cs_ai | arXiv CS.AI | arxiv | rss | True | 24 | https://rss.arxiv.org/rss/cs.AI |

--- a/scripts/datasource.py
+++ b/scripts/datasource.py
@@ -804,6 +804,31 @@ class APIDataSource(DataSource):
 
         return result
 
+    @staticmethod
+    def _crossref_date(row: dict) -> Optional[datetime.datetime]:
+        """Return the best date for deciding whether a Crossref item is new."""
+        for key in (
+            "published-online",
+            "created",
+            "deposited",
+            "indexed",
+            "published",
+            "published-print",
+            "issued",
+        ):
+            value = row.get(key) or {}
+            parts = (value.get("date-parts") or [[]])[0]
+            try:
+                if len(parts) >= 3:
+                    return datetime.datetime(parts[0], parts[1], parts[2])
+                if len(parts) >= 2:
+                    return datetime.datetime(parts[0], parts[1], 1)
+                if len(parts) >= 1:
+                    return datetime.datetime(parts[0], 1, 1)
+            except (ValueError, TypeError):
+                continue
+        return None
+
     def _parse_crossref(self, api_data: dict) -> list[Item]:
         """Crossref REST API (/works) — returns English titles with publication dates."""
         rows = api_data.get("message", {}).get("items", [])
@@ -814,22 +839,7 @@ class APIDataSource(DataSource):
             title = titles[0] if titles else ""
             if not title:
                 continue
-            pub = (
-                row.get("published")
-                or row.get("published-print")
-                or row.get("published-online")
-                or {}
-            )
-            parts = (pub.get("date-parts") or [[]])[0]
-            try:
-                if len(parts) >= 3:
-                    dt: Optional[datetime.datetime] = datetime.datetime(parts[0], parts[1], parts[2])
-                elif len(parts) >= 2:
-                    dt = datetime.datetime(parts[0], parts[1], 1)
-                else:
-                    dt = None
-            except (ValueError, TypeError):
-                dt = None
+            dt = self._crossref_date(row)
             if dt and dt < self._cutoff_dt:
                 continue
             items.append(Item(

--- a/tests/test_datasource_api.py
+++ b/tests/test_datasource_api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timedelta
+from pathlib import Path
 
 from conftest import fixture_path
 
@@ -259,3 +260,50 @@ def test_dlut_api_list_key_shape():
         DEFAULTS,
     )
     assert [it.title for it in ds._parse_dlut_api(api_data)] == ["first"]
+
+
+def test_crossref_parse_uses_online_date_for_new_items():
+    from datasource import APIDataSource
+
+    now = datetime.now()
+    old = now - timedelta(days=60)
+    api_data = {
+        "message": {
+            "items": [
+                {
+                    "title": ["Recently posted online"],
+                    "URL": "https://doi.org/10.3724/example",
+                    "DOI": "10.3724/example",
+                    "published-print": {
+                        "date-parts": [[old.year, old.month, old.day]]
+                    },
+                    "published-online": {
+                        "date-parts": [[now.year, now.month, now.day]]
+                    },
+                }
+            ]
+        }
+    }
+    ds = APIDataSource(
+        {
+            "name": "shuili_xuebao",
+            "category": "papers",
+            "url": "https://api.crossref.org/works",
+            "parser": "crossref",
+            "lookback_hours": 24,
+        },
+        DEFAULTS,
+    )
+
+    items = ds._parse_crossref(api_data)
+
+    assert [item.title for item in items] == ["Recently posted online"]
+    assert items[0].date == now.strftime("%Y-%m-%d")
+
+
+def test_shuili_xuebao_config_sorts_by_updated():
+    cfg_path = Path(__file__).parent.parent / "config" / "sources.json"
+    cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+    source = next(s for s in cfg["sources"] if s["name"] == "shuili_xuebao")
+
+    assert "sort=updated" in source["url"]


### PR DESCRIPTION
## Summary
- change `shuili_xuebao` Crossref query from `sort=published` to `sort=updated`
- prefer Crossref online/created/deposited/indexed dates before print publication dates when filtering new items
- add regression tests for online-date freshness and the `shuili_xuebao` source configuration

Fixes #38.

## Verification
- `uv run pytest -q tests/test_datasource_api.py tests/test_datasource_scrape.py tests/test_run_pipelines.py` -> 70 passed
- Live fetch check: `shuili_xuebao` now returns 18 items from Crossref, with Chinese title enrichment working

## Note
Full suite currently has unrelated failures:
- two weekly-summary tests use a fixed 2026-06-27 fixture that is now outside the current 7-day window
- `tests/test_zotero_sync.py::test_get_zotero_client_returns_client` requires `pyzotero`, which is not installed in this environment
